### PR TITLE
 implement Windows platform compatibility via WSAPoll and IOCP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,11 @@ if(LINUX)
 endif()
 
 if(WIN32)
-    option(BEMAN_NET_WITH_IOCP "Enable IOCP io context (Windows only). Default: OFF. Values: { ON, OFF }." OFF)
+    option(
+        BEMAN_NET_WITH_IOCP
+        "Enable IOCP io context (Windows only). Default: OFF. Values: { ON, OFF }."
+        OFF
+    )
 endif()
 
 include(FetchContent)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@ if(LINUX)
     option(BEMAN_NET_WITH_URING "Enable liburing io context" OFF)
 endif()
 
+if(WIN32)
+    option(BEMAN_NET_WITH_IOCP "Enable IOCP io context (Windows only). Default: OFF. Values: { ON, OFF }." OFF)
+endif()
+
 include(FetchContent)
 
 FetchContent_Declare(

--- a/include/beman/net/detail/internet.hpp
+++ b/include/beman/net/detail/internet.hpp
@@ -133,7 +133,16 @@ class beman::net::ip::address_v6 {
 
     constexpr address_v6() noexcept;
     constexpr address_v6(const address_v6&) noexcept = default;
-    constexpr address_v6(const unsigned char (&addr)[16]) noexcept { ::std::memcpy(d_bytes.data(), addr, 16); }
+    constexpr address_v6(const unsigned char (&addr)[16]) noexcept {
+        // std::memcpy is not constexpr on MSVC; use an explicit loop which is
+        // constexpr on all three platforms under C++20 and later.
+#ifdef _MSC_VER
+        for (int i = 0; i < 16; ++i)
+            d_bytes[i] = addr[i];
+#else
+        ::std::memcpy(d_bytes.data(), addr, 16);
+#endif
+    }
 
     auto           operator=(const address_v6&) noexcept -> address_v6& = default;
     constexpr auto operator==(const address_v6&) const -> bool          = default;

--- a/include/beman/net/detail/io_context.hpp
+++ b/include/beman/net/detail/io_context.hpp
@@ -13,6 +13,8 @@
 #include <beman/net/detail/io_context_scheduler.hpp>
 #ifdef BEMAN_NET_USE_URING
 #include <beman/net/detail/uring_context.hpp>
+#elif defined(BEMAN_NET_USE_IOCP)
+#include <beman/net/detail/iocp_context.hpp>
 #else
 #include <beman/net/detail/poll_context.hpp>
 #endif
@@ -23,7 +25,9 @@
 #include <csignal>
 #include <limits>
 #include <system_error>
-
+#ifndef _MSC_VER
+#include <csignal>
+#endif
 // ----------------------------------------------------------------------------
 
 namespace beman::net {
@@ -36,6 +40,8 @@ class beman::net::io_context {
   private:
 #ifdef BEMAN_NET_USE_URING
     ::std::unique_ptr<::beman::net::detail::context_base> d_owned{new ::beman::net::detail::uring_context()};
+#elif defined(BEMAN_NET_USE_IOCP)
+    ::std::unique_ptr<::beman::net::detail::context_base> d_owned{new ::beman::net::detail::iocp_context()};
 #else
     ::std::unique_ptr<::beman::net::detail::context_base> d_owned{new ::beman::net::detail::poll_context()};
 #endif
@@ -55,7 +61,14 @@ class beman::net::io_context {
     };
     auto get_handle() -> handle { return handle(this); }
 
-    io_context() { std::signal(SIGPIPE, SIG_IGN); }
+    io_context() {
+#ifndef _MSC_VER
+        // SIGPIPE does not exist on Windows; suppress it on POSIX so that
+        // writing to a closed socket returns an error rather than terminating
+        // the process.
+        std::signal(SIGPIPE, SIG_IGN);
+#endif
+    }
     io_context(::beman::net::detail::context_base& context) : d_owned(), d_context(context) {}
     io_context(io_context&&) = delete;
 

--- a/include/beman/net/detail/io_context.hpp
+++ b/include/beman/net/detail/io_context.hpp
@@ -25,9 +25,7 @@
 #include <csignal>
 #include <limits>
 #include <system_error>
-#ifndef _MSC_VER
-#include <csignal>
-#endif
+
 // ----------------------------------------------------------------------------
 
 namespace beman::net {

--- a/include/beman/net/detail/iocp_context.hpp
+++ b/include/beman/net/detail/iocp_context.hpp
@@ -89,6 +89,7 @@ struct iocp_op {
     OVERLAPPED   overlapped{}; // MUST be first - reinterpret_cast relies on it
     io_base*     base{nullptr};
     iocp_op_kind kind{};
+    ::DWORD      flags{0};
 
     explicit iocp_op(io_base* b, iocp_op_kind k) : base(b), kind(k) {}
 };
@@ -103,44 +104,8 @@ struct iocp_op {
 struct beman::net::detail::iocp_record {
     ::SOCKET          socket{INVALID_SOCKET};
     bool              bound{false};
-    ::LPFN_WSARECVMSG pfn_recv_msg{nullptr};
-    ::LPFN_WSASENDMSG pfn_send_msg{nullptr};
 
     explicit iocp_record(::SOCKET s) : socket(s) {}
-
-    auto get_recv_msg() noexcept -> ::LPFN_WSARECVMSG {
-        if (!pfn_recv_msg) {
-            ::GUID  guid = WSAID_WSARECVMSG;
-            ::DWORD n    = 0;
-            ::WSAIoctl(socket,
-                       SIO_GET_EXTENSION_FUNCTION_POINTER,
-                       &guid,
-                       sizeof(guid),
-                       &pfn_recv_msg,
-                       sizeof(pfn_recv_msg),
-                       &n,
-                       nullptr,
-                       nullptr);
-        }
-        return pfn_recv_msg;
-    }
-
-    auto get_send_msg() noexcept -> ::LPFN_WSASENDMSG {
-        if (!pfn_send_msg) {
-            ::GUID  guid = WSAID_WSASENDMSG;
-            ::DWORD n    = 0;
-            ::WSAIoctl(socket,
-                       SIO_GET_EXTENSION_FUNCTION_POINTER,
-                       &guid,
-                       sizeof(guid),
-                       &pfn_send_msg,
-                       sizeof(pfn_send_msg),
-                       &n,
-                       nullptr,
-                       nullptr);
-        }
-        return pfn_send_msg;
-    }
 };
 
 // ----------------------------------------------------------------------------
@@ -182,6 +147,45 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
     timer_priority_t                                                   d_timeouts;
     ::beman::net::detail::context_base::task*                          d_tasks{nullptr};
 
+    //Record the number of asynchronous I/O operations submitted to the kernel.
+    ::std::size_t                                                      d_outstanding_io{0};
+
+    //Keep track of the number of currently active sockets to prevent the event loop from terminating prematurely
+    ::std::size_t                                                      d_socket_count{0};
+
+    // Helper: change d_outstanding_io with logging
+    auto inc_outstanding(const char* reason) -> void {
+        ++this->d_outstanding_io;
+        ::std::cout << "[iocp] outstanding++ (" << reason << ") -> " << this->d_outstanding_io << "\n";
+    }
+    auto dec_outstanding(const char* reason) -> void {
+        --this->d_outstanding_io;
+        ::std::cout << "[iocp] outstanding-- (" << reason << ") -> " << this->d_outstanding_io << "\n";
+    }
+
+    struct deferred_io_task : context_base::task {
+        iocp_context* ctx;
+        io_base*      base;
+        ::DWORD       bytes;
+        deferred_io_task(iocp_context* c, io_base* b, ::DWORD by)
+            : ctx(c), base(b), bytes(by) {
+            ctx->inc_outstanding("deferred_io_task ctor");
+        }
+        auto complete() -> void override {
+            ctx->dec_outstanding("deferred_io_task::complete");
+            ctx->m_current_bytes = this->bytes;
+            ctx->m_current_error = 0;
+            if (this->base->work)
+                this->base->work(*ctx, this->base);
+            delete this;
+        }
+    };
+
+  public:
+    // Used to temporarily store the system state for the Lambda closure after run_one() parsing completes
+    ::DWORD                                                            m_current_bytes{0};
+    int                                                                m_current_error{0};  
+
     // ------------------------------------------------------------------
     // Internal helpers
     // ------------------------------------------------------------------
@@ -189,7 +193,17 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
     auto socket_of(::beman::net::detail::socket_id id) -> ::SOCKET { return this->d_sockets[id].socket; }
 
     auto associate(::SOCKET s) -> bool {
-        return ::CreateIoCompletionPort(reinterpret_cast<HANDLE>(s), this->d_iocp, 0, 0) != nullptr;
+        if (::CreateIoCompletionPort(reinterpret_cast<HANDLE>(s), this->d_iocp, 0, 0) == nullptr)
+            return false;
+        // FILE_SKIP_COMPLETION_PORT_ON_SUCCESS: when WSARecv/WSASend completes
+        // synchronously (rc==0), Windows will NOT post an IOCP completion packet.
+        // This prevents double-completion: our deferred_io_task handles rc==0,
+        // and without this flag the kernel would also post a completion for the
+        // same iocp_op we already deleted, causing a use-after-free crash.
+        ::SetFileCompletionNotificationModes(
+            reinterpret_cast<HANDLE>(s),
+            FILE_SKIP_COMPLETION_PORT_ON_SUCCESS);
+        return true;
     }
 
     static auto make_op(::beman::net::detail::io_base* base, ::beman::net::detail::iocp_op_kind kind)
@@ -212,7 +226,10 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
             return 0u;
         auto* tsk     = this->d_tasks;
         this->d_tasks = tsk->next;
+        ::std::cout << "[iocp] process_task() executing task\n";
         tsk->complete();
+        ::std::cout << "[iocp] process_task() task done, outstanding=" 
+                    << this->d_outstanding_io << " sockets=" << this->d_socket_count << "\n";
         return 1u;
     }
 
@@ -260,38 +277,45 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
     // bytes is the number of bytes transferred (for receive / send).
     auto dispatch(::beman::net::detail::iocp_op* op, ::DWORD bytes, bool ok) -> void {
         auto* base = op->base;
-        auto  kind = op->kind;
+        this->m_current_bytes = bytes;
+        this->m_current_error = ok ? 0 : static_cast<int>(::GetLastError());
+
         delete op;
+        dec_outstanding("dispatch (IOCP completion)");
 
-        if (!ok) {
-            base->error(::std::error_code(static_cast<int>(::GetLastError()), ::std::system_category()));
-            return;
+        if (base->work) {
+            ::std::cout << "[iocp] dispatch calling work, bytes=" << bytes 
+                        << " err=" << this->m_current_error << "\n";
+            ::std::cout.flush();
+            try {
+                base->work(*this, base);
+            } catch (const std::exception& e) {
+                ::std::cout << "[iocp] dispatch work threw exception: " << e.what() << "\n";
+                ::std::cout.flush();
+            } catch (...) {
+                ::std::cout << "[iocp] dispatch work threw unknown exception\n";
+                ::std::cout.flush();
+            }
+            ::std::cout << "[iocp] dispatch work returned\n";
+            ::std::cout.flush();
+        } else {
+            // 没有 work 回调（如 timer），直接处理
+            if (!ok && this->m_current_error == ERROR_OPERATION_ABORTED) {
+                base->cancel();
+            } else if (!ok) {
+                base->error(::std::error_code(this->m_current_error, ::std::system_category()));
+            } else {
+                base->complete();
+            }
         }
 
-        switch (kind) {
-        case ::beman::net::detail::iocp_op_kind::receive: {
-            auto* cmp           = static_cast<receive_operation*>(base);
-            ::std::get<2>(*cmp) = static_cast<::std::size_t>(bytes);
-            cmp->complete();
-            break;
-        }
-        case ::beman::net::detail::iocp_op_kind::send: {
-            auto* cmp           = static_cast<send_operation*>(base);
-            ::std::get<2>(*cmp) = static_cast<::std::size_t>(bytes);
-            cmp->complete();
-            break;
-        }
-        case ::beman::net::detail::iocp_op_kind::accept:
-        case ::beman::net::detail::iocp_op_kind::connect:
-            // accept and connect set up a work callback that finalises the
-            // operation; invoke it now that the kernel part is done.
-            base->work(*this, base);
-            break;
-        case ::beman::net::detail::iocp_op_kind::timer:
-            base->complete();
-            break;
-        }
     }
+
+    // Stored in io_base::extra for the duration of an AcceptEx call.
+    struct accept_state {
+        ::SOCKET accept_sock{INVALID_SOCKET};
+        char*    buf{nullptr};
+    };
 
   public:
     // ------------------------------------------------------------------
@@ -317,6 +341,7 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
     auto make_socket(int fd) -> ::beman::net::detail::socket_id override {
         ::SOCKET s = static_cast<::SOCKET>(fd);
         this->associate(s);
+        ++this->d_socket_count;
         return this->d_sockets.insert(::beman::net::detail::iocp_record(s));
     }
 
@@ -333,7 +358,17 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
             ::closesocket(s);
             return ::beman::net::detail::socket_id::invalid;
         }
+
+        ++this->d_socket_count;
+
         return this->d_sockets.insert(::beman::net::detail::iocp_record(s));
+    }
+
+    // Internal overload that accepts a SOCKET directly, avoiding the int truncation.
+    auto make_socket_from_handle(::SOCKET s) -> ::beman::net::detail::socket_id {
+         this->associate(s);
+         ++this->d_socket_count;
+         return this->d_sockets.insert(::beman::net::detail::iocp_record(s));
     }
 
     auto release(::beman::net::detail::socket_id id, ::std::error_code& error) -> void override {
@@ -341,6 +376,10 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
         this->d_sockets.erase(id);
         if (::closesocket(s) == SOCKET_ERROR)
             error = ::std::error_code(::WSAGetLastError(), ::std::system_category());
+
+        --this->d_socket_count;
+        ::std::cout << "[iocp] release() socket_count -> " << this->d_socket_count 
+                    << " outstanding=" << this->d_outstanding_io << "\n";
     }
 
     auto native_handle(::beman::net::detail::socket_id id) -> ::beman::net::detail::native_handle_type override {
@@ -376,13 +415,21 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
     // ------------------------------------------------------------------
 
     auto run_one() -> ::std::size_t override {
+
+        ::std::cout << "[iocp] run_one() called, outstanding=" 
+                    << this->d_outstanding_io 
+                    << " sockets=" << this->d_socket_count << "\n";
         auto now = ::std::chrono::system_clock::now();
 
         if (0u < this->process_timeout(now) || 0u < this->process_task())
             return 1u;
 
-        if (this->d_timeouts.empty() && !this->d_tasks)
+        if (this->d_timeouts.empty() && !this->d_tasks && this->d_outstanding_io == 0 && this->d_socket_count == 0)
+        {
+            ::std::cout << "[iocp] run_one returning 0 (top-check): outstanding=" 
+                        << this->d_outstanding_io << " sockets=" << this->d_socket_count << "\n";
             return ::std::size_t{};
+        }
 
         while (true) {
             now                    = ::std::chrono::system_clock::now();
@@ -392,19 +439,35 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
             OVERLAPPED* ov         = nullptr;
 
             ::BOOL ok = ::GetQueuedCompletionStatus(this->d_iocp, &bytes, &key, &ov, timeout_ms);
-
+            ::std::cout << "[iocp] GQCS returned ok=" << ok 
+                        << " ov=" << (void*)ov 
+                        << " bytes=" << bytes 
+                        << " err=" << ::GetLastError() << "\n";
             if (ov == nullptr) {
                 // Timeout or wakeup with no real completion.
                 if (0u < this->process_timeout(::std::chrono::system_clock::now()))
                     return 1u;
                 if (0u < this->process_task())
                     return 1u;
-                return ::std::size_t{};
+                ::std::cout << "[iocp] run_one returning 0 via ov==nullptr, outstanding=" << this->d_outstanding_io << "\n";
+                
+                if (this->d_timeouts.empty() && !this->d_tasks && this->d_outstanding_io == 0 && this->d_socket_count == 0) 
+                {
+                    ::std::cout << "[iocp] run_one returning 0 (ov==nullptr): outstanding="
+                                << this->d_outstanding_io << " sockets=" << this->d_socket_count << "\n";
+                    return ::std::size_t{};
+                }
+
+                continue;
+               // return ::std::size_t{};
             }
 
             // Recover our wrapper from the OVERLAPPED pointer.
             // Safe because OVERLAPPED is the first member of iocp_op.
             auto* op = reinterpret_cast<::beman::net::detail::iocp_op*>(ov);
+            ::std::cout << "[iocp] dispatching ov=" << (void*)ov 
+                        << " kind=" << static_cast<int>(op->kind)
+                        << " base=" << (void*)op->base << "\n";
             this->dispatch(op, bytes, ok == TRUE);
             return 1u;
         }
@@ -416,18 +479,38 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
     }
 
     auto schedule(::beman::net::detail::context_base::task* tsk) -> void override {
+        bool was_empty = (this->d_tasks == nullptr);
         tsk->next     = this->d_tasks;
         this->d_tasks = tsk;
-        this->wakeup();
+        //this->wakeup();
+        /*
+        if(was_empty)
+        {
+            this->wakeup();
+        }
+        */
     }
 
     auto cancel(::beman::net::detail::io_base* cancel_op, ::beman::net::detail::io_base* op) -> void override {
-        // CancelIoEx cancels all pending I/O on the socket.
-        // Fine-grained per-operation cancel would require tracking each
-        // OVERLAPPED pointer separately. -dk:TODO
-        ::CancelIoEx(reinterpret_cast<::HANDLE>(this->socket_of(op->id)), nullptr);
-        op->cancel();
+        if (op->id == ::beman::net::detail::socket_id::invalid) 
+        {
+            // Timer: remove from queue and cancel synchronously
+            ::std::cout << "[iocp] cancel() timer op\n";
+            this->d_timeouts.erase(static_cast<timer_node_t*>(op));
+            op->cancel();
+        } else {
+            // Socket IO: async cancel, wait for ERROR_OPERATION_ABORTED from IOCP
+            ::std::cout << "[iocp] cancel() socket io op, calling CancelIoEx\n";
+            ::SOCKET s = this->socket_of(op->id);
+            if (s != INVALID_SOCKET) 
+            {
+                ::CancelIoEx(reinterpret_cast<::HANDLE>(s), nullptr);
+            }
+        }
+        ::std::cout << "[iocp] cancel() calling cancel_op->cancel()\n";
         cancel_op->cancel();
+        ::std::cout << "[iocp] cancel() done, outstanding=" << this->d_outstanding_io 
+                    << " sockets=" << this->d_socket_count << "\n";
     }
 
     // ------------------------------------------------------------------
@@ -436,6 +519,9 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
 
     auto accept(::beman::net::detail::context_base::accept_operation* completion)
         -> ::beman::net::detail::submit_result override {
+
+        ::std::cout << "[iocp] accept() called, d_outstanding_io=" << this->d_outstanding_io << "\n";
+        ::std::cout << "[iocp] AcceptEx submitted\n";
 
         ::SOCKET listen_sock = this->socket_of(completion->id);
 
@@ -449,6 +535,7 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
         }
 
         // AcceptEx requires the accept socket to exist before the call.
+        // Do NOT associate here - make_socket_from_handle in the work callback will do it.
         ::SOCKET accept_sock =
             ::WSASocketW(info.iAddressFamily, info.iSocketType, info.iProtocol, nullptr, 0, WSA_FLAG_OVERLAPPED);
         if (accept_sock == INVALID_SOCKET) {
@@ -463,56 +550,28 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
             return ::beman::net::detail::submit_result::error;
         }
 
-        // AcceptEx address buffer: two sockaddr_storage entries each padded
-        // by 16 bytes, plus zero bytes of receive data.
         static constexpr ::DWORD addr_buf_size = sizeof(::sockaddr_storage) + 16;
         auto*                    buf           = new char[2 * addr_buf_size];
-
-        auto*   op       = make_op(completion, ::beman::net::detail::iocp_op_kind::accept);
-        ::DWORD bytes_rx = 0;
-
-        ::BOOL ok = fn(listen_sock,
-                       accept_sock,
-                       buf,
-                       0, // dwReceiveDataLength
-                       addr_buf_size,
-                       addr_buf_size,
-                       &bytes_rx,
-                       &op->overlapped);
-
-        if (!ok && ::WSAGetLastError() != ERROR_IO_PENDING) {
-            delete[] buf;
-            delete op;
-            ::closesocket(accept_sock);
-            completion->error(::std::error_code(::WSAGetLastError(), ::std::system_category()));
-            return ::beman::net::detail::submit_result::error;
-        }
-
-        // Store accept_sock + address buffer in io_base::extra so they
-        // survive until the IOCP completion arrives.
-        struct accept_state {
-            ::SOCKET accept_sock;
-            char*    buf;
-        };
-        completion->extra = {new accept_state{accept_sock, buf}, +[](void* p) {
-                                 auto* st = static_cast<accept_state*>(p);
-                                 // If still valid at destruction time, close the socket.
-                                 // Normally ownership is transferred to make_socket before
-                                 // this deleter runs.
-                                 if (st->accept_sock != INVALID_SOCKET)
-                                     ::closesocket(st->accept_sock);
-                                 delete[] st->buf;
-                                 delete st;
-                             }};
+        auto*                    op            = make_op(completion, ::beman::net::detail::iocp_op_kind::accept);
+        ::DWORD                  bytes_rx      = 0;
 
         // Set up the work callback that will be invoked by dispatch()
         // once the kernel signals the accept completion.
         completion->work = [](::beman::net::detail::context_base& ctx,
                               ::beman::net::detail::io_base*      base) -> ::beman::net::detail::submit_result {
+            ::std::cout << "[iocp] accept complete, new socket registered\n";
+
             auto& iocp_ctx = static_cast<iocp_context&>(ctx);
             auto* cmp      = static_cast<accept_operation*>(base);
             auto* st       = static_cast<accept_state*>(cmp->extra.get());
 
+            if (iocp_ctx.m_current_error == ERROR_OPERATION_ABORTED || iocp_ctx.m_current_error == WSAECONNRESET) {
+                cmp->cancel();
+                return ::beman::net::detail::submit_result::ready;
+            } else if (iocp_ctx.m_current_error != 0) {
+                cmp->error(::std::error_code(iocp_ctx.m_current_error, ::std::system_category()));
+                return ::beman::net::detail::submit_result::error;
+            }
             // Update the accept socket to inherit the listener's properties.
             ::SOCKET listen_s = iocp_ctx.socket_of(cmp->id);
             ::setsockopt(st->accept_sock,
@@ -524,12 +583,52 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
             // Transfer ownership of the accept socket to the context.
             ::SOCKET accepted   = st->accept_sock;
             st->accept_sock     = INVALID_SOCKET; // prevent double-close
-            ::std::get<2>(*cmp) = iocp_ctx.make_socket(static_cast<int>(accepted));
+            ::std::get<2>(*cmp) = iocp_ctx.make_socket_from_handle(accepted);
+
 
             cmp->extra.reset(); // release accept_state
+            
+
+            ::std::cout << "[iocp] calling accept cmp->complete()\n";
             cmp->complete();
+
+            ::std::cout << "[iocp] after cmp->complete(), returning\n";
             return ::beman::net::detail::submit_result::ready;
         };
+
+        // Store accept_sock + address buffer in io_base::extra so they
+        // survive until the IOCP completion arrives.
+
+        completion->extra = {new accept_state{accept_sock, buf}, +[](void* p) {
+                                 auto* st = static_cast<accept_state*>(p);
+                                 // If still valid at destruction time, close the socket.
+                                 // Normally ownership is transferred to make_socket before
+                                 // this deleter runs.
+                                 if (st->accept_sock != INVALID_SOCKET)
+                                     ::closesocket(st->accept_sock);
+                                 delete[] st->buf;
+                                 delete st;
+                             }};
+
+
+        ::BOOL ok = fn(listen_sock,
+                       accept_sock,
+                       buf,
+                       0, // dwReceiveDataLength
+                       addr_buf_size,
+                       addr_buf_size,
+                       &bytes_rx,
+                       &op->overlapped);
+        
+        if (!ok && ::WSAGetLastError() != ERROR_IO_PENDING) {
+            delete[] buf;
+            delete op;
+            ::closesocket(accept_sock);
+            completion->error(::std::error_code(::WSAGetLastError(), ::std::system_category()));
+            return ::beman::net::detail::submit_result::error;
+        }
+
+        inc_outstanding("accept submitted");
 
         return ::beman::net::detail::submit_result::submit;
     }
@@ -552,6 +651,32 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
             return ::beman::net::detail::submit_result::error;
         }
 
+        // After ConnectEx completes, SO_UPDATE_CONNECT_CONTEXT is required
+        // before the socket can be used for send / receive.
+        op->work = [](::beman::net::detail::context_base& ctx,
+                      ::beman::net::detail::io_base*      base) -> ::beman::net::detail::submit_result {
+            auto& iocp_ctx = static_cast<iocp_context&>(ctx);
+
+            // Explicitly cast nullptr to const char* to avoid an ambiguous overload (C2668).
+            // platform.hpp provides a POSIX-compatible setsockopt taking const void*, which
+            // conflicts with the native Winsock version (const char*) when passing nullptr.
+            auto& iocp = static_cast<iocp_context&>(ctx);
+            if (iocp.m_current_error == ERROR_OPERATION_ABORTED) {
+                base->cancel();
+                return ::beman::net::detail::submit_result::ready;
+            } else if (iocp.m_current_error != 0) {
+                base->error(::std::error_code(iocp.m_current_error, ::std::system_category()));
+                return ::beman::net::detail::submit_result::error;
+            }
+            ::setsockopt(iocp_ctx.socket_of(base->id),
+                         SOL_SOCKET,
+                         SO_UPDATE_CONNECT_CONTEXT,
+                         static_cast<const char*>(nullptr),
+                         0);
+            base->complete();
+            return ::beman::net::detail::submit_result::ready;
+        };
+
         const auto& ep         = ::std::get<0>(*op);
         auto*       iocp_op_   = make_op(op, ::beman::net::detail::iocp_op_kind::connect);
         ::DWORD     bytes_sent = 0;
@@ -564,23 +689,7 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
             return ::beman::net::detail::submit_result::error;
         }
 
-        // After ConnectEx completes, SO_UPDATE_CONNECT_CONTEXT is required
-        // before the socket can be used for send / receive.
-        op->work = [](::beman::net::detail::context_base& ctx,
-                      ::beman::net::detail::io_base*      base) -> ::beman::net::detail::submit_result {
-            auto& iocp_ctx = static_cast<iocp_context&>(ctx);
-
-            // Explicitly cast nullptr to const char* to avoid an ambiguous overload (C2668).
-            // platform.hpp provides a POSIX-compatible setsockopt taking const void*, which
-            // conflicts with the native Winsock version (const char*) when passing nullptr.
-            ::setsockopt(iocp_ctx.socket_of(base->id),
-                         SOL_SOCKET,
-                         SO_UPDATE_CONNECT_CONTEXT,
-                         static_cast<const char*>(nullptr),
-                         0);
-            base->complete();
-            return ::beman::net::detail::submit_result::ready;
-        };
+        inc_outstanding("connect submitted");
 
         return ::beman::net::detail::submit_result::submit;
     }
@@ -594,31 +703,51 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
         auto* iocp_op_ = make_op(op, ::beman::net::detail::iocp_op_kind::receive);
 
         ::msghdr* msg   = &::std::get<0>(*op);
-        ::DWORD   flags = static_cast<::DWORD>(::std::get<1>(*op));
-        ::DWORD   bytes = 0;
+        iocp_op_->flags = static_cast<::DWORD>(::std::get<1>(*op));
         int       rc    = SOCKET_ERROR;
 
-        ::LPFN_WSARECVMSG pfn = rec.get_recv_msg();
-        if (pfn) {
-            // Use WSARecvMsg for full scatter-gather + ancillary data support.
-            ::WSABUF bufs[16];
-            ::ULONG  n  = (msg->msg_iovlen < 16) ? msg->msg_iovlen : 16;
-            ::WSAMSG wm = msg->to_wsamsg(bufs, n);
-            rc          = pfn(rec.socket, &wm, &bytes, &iocp_op_->overlapped, nullptr);
-        } else {
-            // Fallback to plain WSARecv.
-            ::WSABUF bufs[16];
-            ::ULONG  n = (msg->msg_iovlen < 16) ? msg->msg_iovlen : 16;
-            for (::ULONG i = 0; i < n; ++i)
-                bufs[i] = static_cast<::WSABUF>(msg->msg_iov[i]);
-            rc = ::WSARecv(rec.socket, bufs, n, &bytes, &flags, &iocp_op_->overlapped, nullptr);
-        }
+        op->work = [](::beman::net::detail::context_base& ctx, ::beman::net::detail::io_base* base) -> ::beman::net::detail::submit_result {
+            auto& iocp = static_cast<iocp_context&>(ctx);
+            auto* cmp  = static_cast<receive_operation*>(base);
+            
+            if (iocp.m_current_error == ERROR_OPERATION_ABORTED || iocp.m_current_error == WSAECONNRESET) {
+                cmp->cancel();
+                return ::beman::net::detail::submit_result::ready;
+            } else if (iocp.m_current_error != 0) {
+                cmp->error(::std::error_code(iocp.m_current_error, ::std::system_category()));
+                return ::beman::net::detail::submit_result::error;
+            }
 
+            ::std::get<2>(*cmp) = static_cast<::std::size_t>(iocp.m_current_bytes);
+            cmp->complete();
+            return ::beman::net::detail::submit_result::ready;
+        };
+
+        ::WSABUF bufs[16];
+        ::ULONG  n = (msg->msg_iovlen < 16) ? msg->msg_iovlen : 16;
+        for (::ULONG i = 0; i < n; ++i)
+                bufs[i] = static_cast<::WSABUF>(msg->msg_iov[i]);
+
+        ::DWORD bytes_sync = 0;  
+        rc = ::WSARecv(rec.socket, bufs, n, &bytes_sync, &iocp_op_->flags, &iocp_op_->overlapped, nullptr);
+        ::std::cout << "[iocp] WSARecv submitted rc=" << rc 
+            << " err=" << ::WSAGetLastError() << "\n";
+        
+        if (rc == 0) {
+            ::std::cout << "[iocp] WSARecv sync complete, bytes=" << bytes_sync << ", using deferred_io_task\n";
+            delete iocp_op_; 
+            this->schedule(new deferred_io_task(this, op, bytes_sync));
+            return ::beman::net::detail::submit_result::submit; 
+        }
+        
+        
         if (rc == SOCKET_ERROR && ::WSAGetLastError() != WSA_IO_PENDING) {
             delete iocp_op_;
             op->error(::std::error_code(::WSAGetLastError(), ::std::system_category()));
             return ::beman::net::detail::submit_result::error;
         }
+
+        inc_outstanding("WSARecv submitted async");
 
         return ::beman::net::detail::submit_result::submit;
     }
@@ -630,29 +759,52 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
         auto& rec      = this->d_sockets[op->id];
         auto* iocp_op_ = make_op(op, ::beman::net::detail::iocp_op_kind::send);
 
+        op->work = [](::beman::net::detail::context_base& ctx, ::beman::net::detail::io_base* base) -> ::beman::net::detail::submit_result {
+            auto& iocp = static_cast<iocp_context&>(ctx);
+            auto* cmp  = static_cast<send_operation*>(base);
+            
+            if (iocp.m_current_error == ERROR_OPERATION_ABORTED) {
+                cmp->cancel();
+                return ::beman::net::detail::submit_result::ready;
+            } else if (iocp.m_current_error != 0) {
+                cmp->error(::std::error_code(iocp.m_current_error, ::std::system_category()));
+                return ::beman::net::detail::submit_result::error;
+            }
+
+            ::std::get<2>(*cmp) = static_cast<::std::size_t>(iocp.m_current_bytes);
+            cmp->complete();
+            return ::beman::net::detail::submit_result::ready;
+        };
+
         ::msghdr* msg   = &::std::get<0>(*op);
-        ::DWORD   bytes = 0;
         int       rc    = SOCKET_ERROR;
 
-        ::LPFN_WSASENDMSG pfn = rec.get_send_msg();
-        if (pfn) {
-            ::WSABUF bufs[16];
-            ::ULONG  n  = (msg->msg_iovlen < 16) ? msg->msg_iovlen : 16;
-            ::WSAMSG wm = msg->to_wsamsg(bufs, n);
-            rc          = pfn(rec.socket, &wm, 0, &bytes, &iocp_op_->overlapped, nullptr);
-        } else {
-            ::WSABUF bufs[16];
-            ::ULONG  n = (msg->msg_iovlen < 16) ? msg->msg_iovlen : 16;
-            for (::ULONG i = 0; i < n; ++i)
+        ::WSABUF bufs[16];
+        ::ULONG  n = (msg->msg_iovlen < 16) ? msg->msg_iovlen : 16;
+        for (::ULONG i = 0; i < n; ++i)
                 bufs[i] = static_cast<::WSABUF>(msg->msg_iov[i]);
-            rc = ::WSASend(rec.socket, bufs, n, &bytes, 0, &iocp_op_->overlapped, nullptr);
-        }
 
+ 
+        ::DWORD bytes_sync = 0;
+        rc = ::WSASend(rec.socket, bufs, n, &bytes_sync, 0, &iocp_op_->overlapped, nullptr);
+        ::std::cout << "[iocp] WSASend submitted rc=" << rc
+            << " err=" << ::WSAGetLastError() << "\n";
+        
+        if (rc == 0) {
+            ::std::cout << "[iocp] WSASend sync complete, bytes=" << bytes_sync << ", using deferred_io_task\n";
+            delete iocp_op_;
+            this->schedule(new deferred_io_task(this, op, bytes_sync));
+            return ::beman::net::detail::submit_result::submit;
+        }
+       
+        
         if (rc == SOCKET_ERROR && ::WSAGetLastError() != WSA_IO_PENDING) {
             delete iocp_op_;
             op->error(::std::error_code(::WSAGetLastError(), ::std::system_category()));
             return ::beman::net::detail::submit_result::error;
         }
+
+        inc_outstanding("WSASend submitted async");
 
         return ::beman::net::detail::submit_result::submit;
     }
@@ -661,6 +813,9 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
 
     auto resume_at(::beman::net::detail::context_base::resume_at_operation* op)
         -> ::beman::net::detail::submit_result override {
+
+        op->id = ::beman::net::detail::socket_id::invalid;
+            
         if (::std::chrono::system_clock::now() < ::std::get<0>(*op)) {
             this->d_timeouts.insert(op);
             return ::beman::net::detail::submit_result::submit;

--- a/include/beman/net/detail/iocp_context.hpp
+++ b/include/beman/net/detail/iocp_context.hpp
@@ -114,9 +114,13 @@ struct beman::net::detail::iocp_record {
             ::DWORD n    = 0;
             ::WSAIoctl(socket,
                        SIO_GET_EXTENSION_FUNCTION_POINTER,
-                       &guid, sizeof(guid),
-                       &pfn_recv_msg, sizeof(pfn_recv_msg),
-                       &n, nullptr, nullptr);
+                       &guid,
+                       sizeof(guid),
+                       &pfn_recv_msg,
+                       sizeof(pfn_recv_msg),
+                       &n,
+                       nullptr,
+                       nullptr);
         }
         return pfn_recv_msg;
     }
@@ -127,9 +131,13 @@ struct beman::net::detail::iocp_record {
             ::DWORD n    = 0;
             ::WSAIoctl(socket,
                        SIO_GET_EXTENSION_FUNCTION_POINTER,
-                       &guid, sizeof(guid),
-                       &pfn_send_msg, sizeof(pfn_send_msg),
-                       &n, nullptr, nullptr);
+                       &guid,
+                       sizeof(guid),
+                       &pfn_send_msg,
+                       sizeof(pfn_send_msg),
+                       &n,
+                       nullptr,
+                       nullptr);
         }
         return pfn_send_msg;
     }
@@ -140,6 +148,22 @@ struct beman::net::detail::iocp_record {
 // ----------------------------------------------------------------------------
 
 struct beman::net::detail::iocp_context final : ::beman::net::detail::context_base {
+#ifdef _MSC_VER
+    // On Windows, Winsock must be initialised before any socket call.
+    // This RAII guard calls WSAStartup on construction and WSACleanup on
+    // destruction, tying the Winsock lifetime to the poll_context object.
+    struct wsa_guard {
+        wsa_guard() {
+            ::WSADATA wd{};
+            if (::WSAStartup(MAKEWORD(2, 2), &wd) != 0)
+                throw ::std::system_error(::WSAGetLastError(), ::std::system_category(), "WSAStartup failed");
+        }
+        ~wsa_guard() { ::WSACleanup(); }
+        wsa_guard(const wsa_guard&)            = delete;
+        wsa_guard& operator=(const wsa_guard&) = delete;
+    } d_wsa; // constructed first, destroyed last
+#endif
+
   private:
     // ------------------------------------------------------------------
     // Types
@@ -150,8 +174,7 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
     struct get_time {
         auto operator()(auto* t) const -> time_t { return ::std::get<0>(*t); }
     };
-    using timer_priority_t =
-        ::beman::net::detail::sorted_list<timer_node_t, ::std::less<>, get_time>;
+    using timer_priority_t = ::beman::net::detail::sorted_list<timer_node_t, ::std::less<>, get_time>;
 
     // ------------------------------------------------------------------
     // RAII Winsock initialisation
@@ -160,9 +183,7 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
         wsa_guard() {
             ::WSADATA wd{};
             if (::WSAStartup(MAKEWORD(2, 2), &wd) != 0)
-                throw ::std::system_error(::WSAGetLastError(),
-                                          ::std::system_category(),
-                                          "WSAStartup failed");
+                throw ::std::system_error(::WSAGetLastError(), ::std::system_category(), "WSAStartup failed");
         }
         ~wsa_guard() { ::WSACleanup(); }
         wsa_guard(const wsa_guard&)            = delete;
@@ -172,26 +193,22 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
     // ------------------------------------------------------------------
     // State
     // ------------------------------------------------------------------
-    ::HANDLE                                                             d_iocp{INVALID_HANDLE_VALUE};
-    ::beman::net::detail::container<::beman::net::detail::iocp_record>  d_sockets;
-    timer_priority_t                                                     d_timeouts;
-    ::beman::net::detail::context_base::task*                            d_tasks{nullptr};
+    ::HANDLE                                                           d_iocp{INVALID_HANDLE_VALUE};
+    ::beman::net::detail::container<::beman::net::detail::iocp_record> d_sockets;
+    timer_priority_t                                                   d_timeouts;
+    ::beman::net::detail::context_base::task*                          d_tasks{nullptr};
 
     // ------------------------------------------------------------------
     // Internal helpers
     // ------------------------------------------------------------------
 
-    auto socket_of(::beman::net::detail::socket_id id) -> ::SOCKET {
-        return this->d_sockets[id].socket;
-    }
+    auto socket_of(::beman::net::detail::socket_id id) -> ::SOCKET { return this->d_sockets[id].socket; }
 
     auto associate(::SOCKET s) -> bool {
-        return ::CreateIoCompletionPort(reinterpret_cast<HANDLE>(s),
-                                        this->d_iocp, 0, 0) != nullptr;
+        return ::CreateIoCompletionPort(reinterpret_cast<HANDLE>(s), this->d_iocp, 0, 0) != nullptr;
     }
 
-    static auto make_op(::beman::net::detail::io_base* base,
-                        ::beman::net::detail::iocp_op_kind kind)
+    static auto make_op(::beman::net::detail::io_base* base, ::beman::net::detail::iocp_op_kind kind)
         -> ::beman::net::detail::iocp_op* {
         return new ::beman::net::detail::iocp_op(base, kind);
     }
@@ -202,13 +219,13 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
         auto next = ::std::get<0>(*this->d_timeouts.front());
         if (next <= now)
             return 0;
-        auto ms = ::std::chrono::duration_cast<::std::chrono::milliseconds>(
-                      next - now).count();
+        auto ms = ::std::chrono::duration_cast<::std::chrono::milliseconds>(next - now).count();
         return static_cast<::DWORD>(ms < 0 ? 0 : ms);
     }
 
     auto process_task() -> ::std::size_t {
-        if (!this->d_tasks) return 0u;
+        if (!this->d_tasks)
+            return 0u;
         auto* tsk     = this->d_tasks;
         this->d_tasks = tsk->next;
         tsk->complete();
@@ -216,8 +233,7 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
     }
 
     auto process_timeout(const time_t& now) -> ::std::size_t {
-        if (!this->d_timeouts.empty() &&
-            ::std::get<0>(*this->d_timeouts.front()) <= now) {
+        if (!this->d_timeouts.empty() && ::std::get<0>(*this->d_timeouts.front()) <= now) {
             this->d_timeouts.pop_front()->complete();
             return 1u;
         }
@@ -225,20 +241,18 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
     }
 
     static auto load_accept_ex(::SOCKET s) noexcept -> ::LPFN_ACCEPTEX {
-        ::LPFN_ACCEPTEX fn = nullptr;
-        ::GUID guid        = WSAID_ACCEPTEX;
-        ::DWORD n          = 0;
-        ::WSAIoctl(s, SIO_GET_EXTENSION_FUNCTION_POINTER,
-                   &guid, sizeof(guid), &fn, sizeof(fn), &n, nullptr, nullptr);
+        ::LPFN_ACCEPTEX fn   = nullptr;
+        ::GUID          guid = WSAID_ACCEPTEX;
+        ::DWORD         n    = 0;
+        ::WSAIoctl(s, SIO_GET_EXTENSION_FUNCTION_POINTER, &guid, sizeof(guid), &fn, sizeof(fn), &n, nullptr, nullptr);
         return fn;
     }
 
     static auto load_connect_ex(::SOCKET s) noexcept -> ::LPFN_CONNECTEX {
-        ::LPFN_CONNECTEX fn = nullptr;
-        ::GUID guid         = WSAID_CONNECTEX;
-        ::DWORD n           = 0;
-        ::WSAIoctl(s, SIO_GET_EXTENSION_FUNCTION_POINTER,
-                   &guid, sizeof(guid), &fn, sizeof(fn), &n, nullptr, nullptr);
+        ::LPFN_CONNECTEX fn   = nullptr;
+        ::GUID           guid = WSAID_CONNECTEX;
+        ::DWORD          n    = 0;
+        ::WSAIoctl(s, SIO_GET_EXTENSION_FUNCTION_POINTER, &guid, sizeof(guid), &fn, sizeof(fn), &n, nullptr, nullptr);
         return fn;
     }
 
@@ -246,13 +260,13 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
     // ConnectEx requires a prior bind.
     auto ensure_bound(::beman::net::detail::socket_id id) -> bool {
         auto& rec = this->d_sockets[id];
-        if (rec.bound) return true;
+        if (rec.bound)
+            return true;
         ::sockaddr_in addr{};
         addr.sin_family      = AF_INET;
         addr.sin_addr.s_addr = INADDR_ANY;
         addr.sin_port        = 0;
-        if (::bind(rec.socket, reinterpret_cast<::sockaddr*>(&addr),
-                   sizeof(addr)) == SOCKET_ERROR)
+        if (::bind(rec.socket, reinterpret_cast<::sockaddr*>(&addr), sizeof(addr)) == SOCKET_ERROR)
             return false;
         rec.bound = true;
         return true;
@@ -260,28 +274,25 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
 
     // Dispatch a completion to the appropriate io_base.
     // bytes is the number of bytes transferred (for receive / send).
-    auto dispatch(::beman::net::detail::iocp_op* op,
-                  ::DWORD                        bytes,
-                  bool                           ok) -> void {
+    auto dispatch(::beman::net::detail::iocp_op* op, ::DWORD bytes, bool ok) -> void {
         auto* base = op->base;
         auto  kind = op->kind;
         delete op;
 
         if (!ok) {
-            base->error(::std::error_code(static_cast<int>(::GetLastError()),
-                                          ::std::system_category()));
+            base->error(::std::error_code(static_cast<int>(::GetLastError()), ::std::system_category()));
             return;
         }
 
         switch (kind) {
         case ::beman::net::detail::iocp_op_kind::receive: {
-            auto* cmp = static_cast<receive_operation*>(base);
+            auto* cmp           = static_cast<receive_operation*>(base);
             ::std::get<2>(*cmp) = static_cast<::std::size_t>(bytes);
             cmp->complete();
             break;
         }
         case ::beman::net::detail::iocp_op_kind::send: {
-            auto* cmp = static_cast<send_operation*>(base);
+            auto* cmp           = static_cast<send_operation*>(base);
             ::std::get<2>(*cmp) = static_cast<::std::size_t>(bytes);
             cmp->complete();
             break;
@@ -304,12 +315,10 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
     // ------------------------------------------------------------------
 
     iocp_context() {
-        this->d_iocp = ::CreateIoCompletionPort(INVALID_HANDLE_VALUE,
-                                                 nullptr, 0, 1);
+        this->d_iocp = ::CreateIoCompletionPort(INVALID_HANDLE_VALUE, nullptr, 0, 1);
         if (!this->d_iocp || this->d_iocp == INVALID_HANDLE_VALUE)
-            throw ::std::system_error(static_cast<int>(::GetLastError()),
-                                      ::std::system_category(),
-                                      "CreateIoCompletionPort failed");
+            throw ::std::system_error(
+                static_cast<int>(::GetLastError()), ::std::system_category(), "CreateIoCompletionPort failed");
     }
 
     ~iocp_context() override {
@@ -327,67 +336,55 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
         return this->d_sockets.insert(::beman::net::detail::iocp_record(s));
     }
 
-    auto make_socket(int domain, int type, int protocol,
-                     ::std::error_code& error)
+    auto make_socket(int domain, int type, int protocol, ::std::error_code& error)
         -> ::beman::net::detail::socket_id override {
         // WSA_FLAG_OVERLAPPED is required for IOCP.
-        ::SOCKET s = ::WSASocketW(domain, type, protocol,
-                                   nullptr, 0, WSA_FLAG_OVERLAPPED);
+        ::SOCKET s = ::WSASocketW(domain, type, protocol, nullptr, 0, WSA_FLAG_OVERLAPPED);
         if (s == INVALID_SOCKET) {
-            error = ::std::error_code(::WSAGetLastError(),
-                                      ::std::system_category());
+            error = ::std::error_code(::WSAGetLastError(), ::std::system_category());
             return ::beman::net::detail::socket_id::invalid;
         }
         if (!this->associate(s)) {
-            error = ::std::error_code(static_cast<int>(::GetLastError()),
-                                      ::std::system_category());
+            error = ::std::error_code(static_cast<int>(::GetLastError()), ::std::system_category());
             ::closesocket(s);
             return ::beman::net::detail::socket_id::invalid;
         }
         return this->d_sockets.insert(::beman::net::detail::iocp_record(s));
     }
 
-    auto release(::beman::net::detail::socket_id id,
-                 ::std::error_code& error) -> void override {
+    auto release(::beman::net::detail::socket_id id, ::std::error_code& error) -> void override {
         ::SOCKET s = this->socket_of(id);
         this->d_sockets.erase(id);
         if (::closesocket(s) == SOCKET_ERROR)
-            error = ::std::error_code(::WSAGetLastError(),
-                                      ::std::system_category());
+            error = ::std::error_code(::WSAGetLastError(), ::std::system_category());
     }
 
-    auto native_handle(::beman::net::detail::socket_id id)
-        -> ::beman::net::detail::native_handle_type override {
-        return static_cast<::beman::net::detail::native_handle_type>(
-            this->socket_of(id));
+    auto native_handle(::beman::net::detail::socket_id id) -> ::beman::net::detail::native_handle_type override {
+        return static_cast<::beman::net::detail::native_handle_type>(this->socket_of(id));
     }
 
     auto set_option(::beman::net::detail::socket_id id,
-                    int level, int name,
-                    const void* data, ::socklen_t size,
-                    ::std::error_code& error) -> void override {
-        if (::setsockopt(this->socket_of(id), level, name,
-                         static_cast<const char*>(data), size) == SOCKET_ERROR)
-            error = ::std::error_code(::WSAGetLastError(),
-                                      ::std::system_category());
+                    int                             level,
+                    int                             name,
+                    const void*                     data,
+                    ::socklen_t                     size,
+                    ::std::error_code&              error) -> void override {
+        if (::setsockopt(this->socket_of(id), level, name, static_cast<const char*>(data), size) == SOCKET_ERROR)
+            error = ::std::error_code(::WSAGetLastError(), ::std::system_category());
     }
 
-    auto bind(::beman::net::detail::socket_id id,
-              const ::beman::net::detail::endpoint& ep,
-              ::std::error_code& error) -> void override {
+    auto bind(::beman::net::detail::socket_id id, const ::beman::net::detail::endpoint& ep, ::std::error_code& error)
+        -> void override {
         if (::bind(this->socket_of(id), ep.data(), ep.size()) == SOCKET_ERROR) {
-            error = ::std::error_code(::WSAGetLastError(),
-                                      ::std::system_category());
+            error = ::std::error_code(::WSAGetLastError(), ::std::system_category());
             return;
         }
         this->d_sockets[id].bound = true;
     }
 
-    auto listen(::beman::net::detail::socket_id id, int backlog,
-                ::std::error_code& error) -> void override {
+    auto listen(::beman::net::detail::socket_id id, int backlog, ::std::error_code& error) -> void override {
         if (::listen(this->socket_of(id), backlog) == SOCKET_ERROR)
-            error = ::std::error_code(::WSAGetLastError(),
-                                      ::std::system_category());
+            error = ::std::error_code(::WSAGetLastError(), ::std::system_category());
     }
 
     // ------------------------------------------------------------------
@@ -404,19 +401,17 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
             return ::std::size_t{};
 
         while (true) {
-            now = ::std::chrono::system_clock::now();
+            now                    = ::std::chrono::system_clock::now();
             ::DWORD     timeout_ms = this->iocp_timeout_ms(now);
             ::DWORD     bytes      = 0;
             ::ULONG_PTR key        = 0;
             OVERLAPPED* ov         = nullptr;
 
-            ::BOOL ok = ::GetQueuedCompletionStatus(
-                this->d_iocp, &bytes, &key, &ov, timeout_ms);
+            ::BOOL ok = ::GetQueuedCompletionStatus(this->d_iocp, &bytes, &key, &ov, timeout_ms);
 
             if (ov == nullptr) {
                 // Timeout or wakeup with no real completion.
-                if (0u < this->process_timeout(
-                        ::std::chrono::system_clock::now()))
+                if (0u < this->process_timeout(::std::chrono::system_clock::now()))
                     return 1u;
                 if (0u < this->process_task())
                     return 1u;
@@ -436,20 +431,17 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
         ::PostQueuedCompletionStatus(this->d_iocp, 0, 0, nullptr);
     }
 
-    auto schedule(::beman::net::detail::context_base::task* tsk)
-        -> void override {
+    auto schedule(::beman::net::detail::context_base::task* tsk) -> void override {
         tsk->next     = this->d_tasks;
         this->d_tasks = tsk;
         this->wakeup();
     }
 
-    auto cancel(::beman::net::detail::io_base* cancel_op,
-                ::beman::net::detail::io_base* op) -> void override {
+    auto cancel(::beman::net::detail::io_base* cancel_op, ::beman::net::detail::io_base* op) -> void override {
         // CancelIoEx cancels all pending I/O on the socket.
         // Fine-grained per-operation cancel would require tracking each
         // OVERLAPPED pointer separately. -dk:TODO
-        ::CancelIoEx(
-            reinterpret_cast<::HANDLE>(this->socket_of(op->id)), nullptr);
+        ::CancelIoEx(reinterpret_cast<::HANDLE>(this->socket_of(op->id)), nullptr);
         op->cancel();
         cancel_op->cancel();
     }
@@ -465,56 +457,50 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
 
         // Determine address family from the listening socket.
         ::WSAPROTOCOL_INFOW info{};
-        int info_len = sizeof(info);
-        if (::getsockopt(listen_sock, SOL_SOCKET, SO_PROTOCOL_INFOW,
-                         reinterpret_cast<char*>(&info),
-                         &info_len) == SOCKET_ERROR) {
-            completion->error(::std::error_code(::WSAGetLastError(),
-                                                ::std::system_category()));
+        int                 info_len = sizeof(info);
+        if (::getsockopt(listen_sock, SOL_SOCKET, SO_PROTOCOL_INFOW, reinterpret_cast<char*>(&info), &info_len) ==
+            SOCKET_ERROR) {
+            completion->error(::std::error_code(::WSAGetLastError(), ::std::system_category()));
             return ::beman::net::detail::submit_result::error;
         }
 
         // AcceptEx requires the accept socket to exist before the call.
-        ::SOCKET accept_sock = ::WSASocketW(info.iAddressFamily,
-                                             info.iSocketType,
-                                             info.iProtocol,
-                                             nullptr, 0, WSA_FLAG_OVERLAPPED);
+        ::SOCKET accept_sock =
+            ::WSASocketW(info.iAddressFamily, info.iSocketType, info.iProtocol, nullptr, 0, WSA_FLAG_OVERLAPPED);
         if (accept_sock == INVALID_SOCKET) {
-            completion->error(::std::error_code(::WSAGetLastError(),
-                                                ::std::system_category()));
+            completion->error(::std::error_code(::WSAGetLastError(), ::std::system_category()));
             return ::beman::net::detail::submit_result::error;
         }
 
         ::LPFN_ACCEPTEX fn = load_accept_ex(listen_sock);
         if (!fn) {
             ::closesocket(accept_sock);
-            completion->error(::std::error_code(::WSAGetLastError(),
-                                                ::std::system_category()));
+            completion->error(::std::error_code(::WSAGetLastError(), ::std::system_category()));
             return ::beman::net::detail::submit_result::error;
         }
 
         // AcceptEx address buffer: two sockaddr_storage entries each padded
         // by 16 bytes, plus zero bytes of receive data.
-        static constexpr ::DWORD addr_buf_size =
-            sizeof(::sockaddr_storage) + 16;
-        auto* buf = new char[2 * addr_buf_size];
+        static constexpr ::DWORD addr_buf_size = sizeof(::sockaddr_storage) + 16;
+        auto*                    buf           = new char[2 * addr_buf_size];
 
-        auto*  op       = make_op(completion, ::beman::net::detail::iocp_op_kind::accept);
+        auto*   op       = make_op(completion, ::beman::net::detail::iocp_op_kind::accept);
         ::DWORD bytes_rx = 0;
 
-        ::BOOL ok = fn(listen_sock, accept_sock, buf,
-                        0,              // dwReceiveDataLength
-                        addr_buf_size,
-                        addr_buf_size,
-                        &bytes_rx,
-                        &op->overlapped);
+        ::BOOL ok = fn(listen_sock,
+                       accept_sock,
+                       buf,
+                       0, // dwReceiveDataLength
+                       addr_buf_size,
+                       addr_buf_size,
+                       &bytes_rx,
+                       &op->overlapped);
 
         if (!ok && ::WSAGetLastError() != ERROR_IO_PENDING) {
             delete[] buf;
             delete op;
             ::closesocket(accept_sock);
-            completion->error(::std::error_code(::WSAGetLastError(),
-                                                ::std::system_category()));
+            completion->error(::std::error_code(::WSAGetLastError(), ::std::system_category()));
             return ::beman::net::detail::submit_result::error;
         }
 
@@ -524,40 +510,37 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
             ::SOCKET accept_sock;
             char*    buf;
         };
-        completion->extra = {
-            new accept_state{accept_sock, buf},
-            +[](void* p) {
-                auto* st = static_cast<accept_state*>(p);
-                // If still valid at destruction time, close the socket.
-                // Normally ownership is transferred to make_socket before
-                // this deleter runs.
-                if (st->accept_sock != INVALID_SOCKET)
-                    ::closesocket(st->accept_sock);
-                delete[] st->buf;
-                delete st;
-            }};
+        completion->extra = {new accept_state{accept_sock, buf}, +[](void* p) {
+                                 auto* st = static_cast<accept_state*>(p);
+                                 // If still valid at destruction time, close the socket.
+                                 // Normally ownership is transferred to make_socket before
+                                 // this deleter runs.
+                                 if (st->accept_sock != INVALID_SOCKET)
+                                     ::closesocket(st->accept_sock);
+                                 delete[] st->buf;
+                                 delete st;
+                             }};
 
         // Set up the work callback that will be invoked by dispatch()
         // once the kernel signals the accept completion.
         completion->work = [](::beman::net::detail::context_base& ctx,
-                               ::beman::net::detail::io_base*     base)
-            -> ::beman::net::detail::submit_result {
+                              ::beman::net::detail::io_base*      base) -> ::beman::net::detail::submit_result {
             auto& iocp_ctx = static_cast<iocp_context&>(ctx);
             auto* cmp      = static_cast<accept_operation*>(base);
-            auto* st =
-                static_cast<accept_state*>(cmp->extra.get());
+            auto* st       = static_cast<accept_state*>(cmp->extra.get());
 
             // Update the accept socket to inherit the listener's properties.
             ::SOCKET listen_s = iocp_ctx.socket_of(cmp->id);
             ::setsockopt(st->accept_sock,
-                         SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT,
-                         reinterpret_cast<char*>(&listen_s), sizeof(::SOCKET));
+                         SOL_SOCKET,
+                         SO_UPDATE_ACCEPT_CONTEXT,
+                         reinterpret_cast<char*>(&listen_s),
+                         sizeof(::SOCKET));
 
             // Transfer ownership of the accept socket to the context.
-            ::SOCKET accepted       = st->accept_sock;
-            st->accept_sock         = INVALID_SOCKET; // prevent double-close
-            ::std::get<2>(*cmp)     = iocp_ctx.make_socket(
-                static_cast<int>(accepted));
+            ::SOCKET accepted   = st->accept_sock;
+            st->accept_sock     = INVALID_SOCKET; // prevent double-close
+            ::std::get<2>(*cmp) = iocp_ctx.make_socket(static_cast<int>(accepted));
 
             cmp->extra.reset(); // release accept_state
             cmp->complete();
@@ -575,42 +558,34 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
         ::SOCKET s = this->socket_of(op->id);
 
         if (!this->ensure_bound(op->id)) {
-            op->error(::std::error_code(::WSAGetLastError(),
-                                        ::std::system_category()));
+            op->error(::std::error_code(::WSAGetLastError(), ::std::system_category()));
             return ::beman::net::detail::submit_result::error;
         }
 
         ::LPFN_CONNECTEX fn = load_connect_ex(s);
         if (!fn) {
-            op->error(::std::error_code(::WSAGetLastError(),
-                                        ::std::system_category()));
+            op->error(::std::error_code(::WSAGetLastError(), ::std::system_category()));
             return ::beman::net::detail::submit_result::error;
         }
 
-        const auto& ep       = ::std::get<0>(*op);
-        auto*       iocp_op_ = make_op(op, ::beman::net::detail::iocp_op_kind::connect);
+        const auto& ep         = ::std::get<0>(*op);
+        auto*       iocp_op_   = make_op(op, ::beman::net::detail::iocp_op_kind::connect);
         ::DWORD     bytes_sent = 0;
 
-        ::BOOL ok = fn(s, ep.data(), ep.size(),
-                        nullptr, 0, &bytes_sent,
-                        &iocp_op_->overlapped);
+        ::BOOL ok = fn(s, ep.data(), ep.size(), nullptr, 0, &bytes_sent, &iocp_op_->overlapped);
 
         if (!ok && ::WSAGetLastError() != ERROR_IO_PENDING) {
             delete iocp_op_;
-            op->error(::std::error_code(::WSAGetLastError(),
-                                        ::std::system_category()));
+            op->error(::std::error_code(::WSAGetLastError(), ::std::system_category()));
             return ::beman::net::detail::submit_result::error;
         }
 
         // After ConnectEx completes, SO_UPDATE_CONNECT_CONTEXT is required
         // before the socket can be used for send / receive.
         op->work = [](::beman::net::detail::context_base& ctx,
-                       ::beman::net::detail::io_base*     base)
-            -> ::beman::net::detail::submit_result {
+                      ::beman::net::detail::io_base*      base) -> ::beman::net::detail::submit_result {
             auto& iocp_ctx = static_cast<iocp_context&>(ctx);
-            ::setsockopt(iocp_ctx.socket_of(base->id),
-                         SOL_SOCKET, SO_UPDATE_CONNECT_CONTEXT,
-                         nullptr, 0);
+            ::setsockopt(iocp_ctx.socket_of(base->id), SOL_SOCKET, SO_UPDATE_CONNECT_CONTEXT, nullptr, 0);
             base->complete();
             return ::beman::net::detail::submit_result::ready;
         };
@@ -623,7 +598,7 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
     auto receive(::beman::net::detail::context_base::receive_operation* op)
         -> ::beman::net::detail::submit_result override {
 
-        auto& rec    = this->d_sockets[op->id];
+        auto& rec      = this->d_sockets[op->id];
         auto* iocp_op_ = make_op(op, ::beman::net::detail::iocp_op_kind::receive);
 
         ::msghdr* msg   = &::std::get<0>(*op);
@@ -637,22 +612,19 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
             ::WSABUF bufs[16];
             ::ULONG  n  = (msg->msg_iovlen < 16) ? msg->msg_iovlen : 16;
             ::WSAMSG wm = msg->to_wsamsg(bufs, n);
-            rc = pfn(rec.socket, &wm, &bytes, &iocp_op_->overlapped, nullptr);
+            rc          = pfn(rec.socket, &wm, &bytes, &iocp_op_->overlapped, nullptr);
         } else {
             // Fallback to plain WSARecv.
             ::WSABUF bufs[16];
             ::ULONG  n = (msg->msg_iovlen < 16) ? msg->msg_iovlen : 16;
             for (::ULONG i = 0; i < n; ++i)
                 bufs[i] = static_cast<::WSABUF>(msg->msg_iov[i]);
-            rc = ::WSARecv(rec.socket, bufs, n,
-                           &bytes, &flags,
-                           &iocp_op_->overlapped, nullptr);
+            rc = ::WSARecv(rec.socket, bufs, n, &bytes, &flags, &iocp_op_->overlapped, nullptr);
         }
 
         if (rc == SOCKET_ERROR && ::WSAGetLastError() != WSA_IO_PENDING) {
             delete iocp_op_;
-            op->error(::std::error_code(::WSAGetLastError(),
-                                        ::std::system_category()));
+            op->error(::std::error_code(::WSAGetLastError(), ::std::system_category()));
             return ::beman::net::detail::submit_result::error;
         }
 
@@ -661,10 +633,9 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
 
     // ------------------------------------------------------------------
 
-    auto send(::beman::net::detail::context_base::send_operation* op)
-        -> ::beman::net::detail::submit_result override {
+    auto send(::beman::net::detail::context_base::send_operation* op) -> ::beman::net::detail::submit_result override {
 
-        auto& rec    = this->d_sockets[op->id];
+        auto& rec      = this->d_sockets[op->id];
         auto* iocp_op_ = make_op(op, ::beman::net::detail::iocp_op_kind::send);
 
         ::msghdr* msg   = &::std::get<0>(*op);
@@ -676,22 +647,18 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
             ::WSABUF bufs[16];
             ::ULONG  n  = (msg->msg_iovlen < 16) ? msg->msg_iovlen : 16;
             ::WSAMSG wm = msg->to_wsamsg(bufs, n);
-            rc = pfn(rec.socket, &wm, 0, &bytes,
-                     &iocp_op_->overlapped, nullptr);
+            rc          = pfn(rec.socket, &wm, 0, &bytes, &iocp_op_->overlapped, nullptr);
         } else {
             ::WSABUF bufs[16];
             ::ULONG  n = (msg->msg_iovlen < 16) ? msg->msg_iovlen : 16;
             for (::ULONG i = 0; i < n; ++i)
                 bufs[i] = static_cast<::WSABUF>(msg->msg_iov[i]);
-            rc = ::WSASend(rec.socket, bufs, n,
-                           &bytes, 0,
-                           &iocp_op_->overlapped, nullptr);
+            rc = ::WSASend(rec.socket, bufs, n, &bytes, 0, &iocp_op_->overlapped, nullptr);
         }
 
         if (rc == SOCKET_ERROR && ::WSAGetLastError() != WSA_IO_PENDING) {
             delete iocp_op_;
-            op->error(::std::error_code(::WSAGetLastError(),
-                                        ::std::system_category()));
+            op->error(::std::error_code(::WSAGetLastError(), ::std::system_category()));
             return ::beman::net::detail::submit_result::error;
         }
 

--- a/include/beman/net/detail/iocp_context.hpp
+++ b/include/beman/net/detail/iocp_context.hpp
@@ -1,0 +1,717 @@
+// include/beman/net/detail/iocp_context.hpp                        -*-C++-*-
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef INCLUDED_BEMAN_NET_DETAIL_IOCP_CONTEXT
+#define INCLUDED_BEMAN_NET_DETAIL_IOCP_CONTEXT
+
+// This file is only meaningful on Windows / MSVC.
+#ifdef _MSC_VER
+
+// ----------------------------------------------------------------------------
+// Overview
+// --------
+// iocp_context implements context_base using Windows I/O Completion Ports
+// (IOCP).  It is selected at compile time when BEMAN_NET_USE_IOCP is defined,
+// which is set by CMake when -DBEMAN_NET_WITH_IOCP=ON is passed.
+//
+// Key design decisions
+// --------------------
+//
+// 1. iocp_op / OVERLAPPED lifetime
+//    Every pending async operation is represented by an iocp_op object that
+//    embeds an OVERLAPPED as its *first* member.  GetQueuedCompletionStatus
+//    returns a pointer to that OVERLAPPED; we recover the enclosing iocp_op
+//    via reinterpret_cast (safe because OVERLAPPED is at offset 0).
+//    Each iocp_op also stores an op_kind tag so run_one() can dispatch the
+//    completion without RTTI / dynamic_cast.
+//
+// 2. native_handle_type vs SOCKET
+//    netfwd.hpp defines native_handle_type as std::uintptr_t on Windows
+//    (changed from int to avoid truncating the 64-bit SOCKET value).
+//    iocp_record stores the real SOCKET; socket_of() converts a socket_id
+//    to a SOCKET through the record table.
+//
+// 3. AcceptEx quirks
+//    AcceptEx requires the accept socket to be created before the call, and
+//    needs a caller-supplied buffer for local + remote addresses.  We store
+//    both in an accept_state held by io_base::extra (a unique_ptr<void>).
+//
+// 4. ConnectEx quirks
+//    ConnectEx requires the connecting socket to be bound first.  We bind to
+//    INADDR_ANY:0 implicitly (ensure_bound) when the socket has not been
+//    explicitly bound yet.
+//
+// 5. WSARecvMsg / WSASendMsg
+//    Both are Winsock extension functions that must be loaded dynamically via
+//    WSAIoctl.  We cache the function pointers per-socket in iocp_record.
+//    A plain WSARecv / WSASend fallback is used if loading fails.
+//
+// 6. Timers
+//    Implemented identically to poll_context: a sorted_list keyed on
+//    time_point, checked on every run_one() call.  The IOCP wait timeout is
+//    derived from the nearest timer deadline so we never sleep longer than
+//    needed.
+//
+// 7. WSAStartup / WSACleanup
+//    Managed by an RAII wsa_guard member so the lifetime is tied to the
+//    iocp_context object.
+// ----------------------------------------------------------------------------
+
+#include <beman/net/detail/platform.hpp>
+#include <beman/net/detail/netfwd.hpp>
+#include <beman/net/detail/container.hpp>
+#include <beman/net/detail/context_base.hpp>
+#include <beman/net/detail/sorted_list.hpp>
+#include <cassert>
+#include <chrono>
+#include <iostream>
+#include <vector>
+
+// ----------------------------------------------------------------------------
+
+namespace beman::net::detail {
+struct iocp_record;
+struct iocp_context;
+} // namespace beman::net::detail
+
+// ----------------------------------------------------------------------------
+// iocp_op
+// Wraps OVERLAPPED together with a back-pointer to the logical io_base and
+// a tag that identifies the operation kind so run_one() can dispatch without
+// RTTI.
+// ----------------------------------------------------------------------------
+
+namespace beman::net::detail {
+
+enum class iocp_op_kind : unsigned char { accept, connect, receive, send, timer };
+
+struct iocp_op {
+    OVERLAPPED   overlapped{}; // MUST be first – reinterpret_cast relies on it
+    io_base*     base{nullptr};
+    iocp_op_kind kind{};
+
+    explicit iocp_op(io_base* b, iocp_op_kind k) : base(b), kind(k) {}
+};
+
+} // namespace beman::net::detail
+
+// ----------------------------------------------------------------------------
+// iocp_record
+// Per-socket state stored in the container<> indexed by socket_id.
+// ----------------------------------------------------------------------------
+
+struct beman::net::detail::iocp_record {
+    ::SOCKET          socket{INVALID_SOCKET};
+    bool              bound{false};
+    ::LPFN_WSARECVMSG pfn_recv_msg{nullptr};
+    ::LPFN_WSASENDMSG pfn_send_msg{nullptr};
+
+    explicit iocp_record(::SOCKET s) : socket(s) {}
+
+    auto get_recv_msg() noexcept -> ::LPFN_WSARECVMSG {
+        if (!pfn_recv_msg) {
+            ::GUID  guid = WSAID_WSARECVMSG;
+            ::DWORD n    = 0;
+            ::WSAIoctl(socket,
+                       SIO_GET_EXTENSION_FUNCTION_POINTER,
+                       &guid, sizeof(guid),
+                       &pfn_recv_msg, sizeof(pfn_recv_msg),
+                       &n, nullptr, nullptr);
+        }
+        return pfn_recv_msg;
+    }
+
+    auto get_send_msg() noexcept -> ::LPFN_WSASENDMSG {
+        if (!pfn_send_msg) {
+            ::GUID  guid = WSAID_WSASENDMSG;
+            ::DWORD n    = 0;
+            ::WSAIoctl(socket,
+                       SIO_GET_EXTENSION_FUNCTION_POINTER,
+                       &guid, sizeof(guid),
+                       &pfn_send_msg, sizeof(pfn_send_msg),
+                       &n, nullptr, nullptr);
+        }
+        return pfn_send_msg;
+    }
+};
+
+// ----------------------------------------------------------------------------
+// iocp_context
+// ----------------------------------------------------------------------------
+
+struct beman::net::detail::iocp_context final : ::beman::net::detail::context_base {
+  private:
+    // ------------------------------------------------------------------
+    // Types
+    // ------------------------------------------------------------------
+    using time_t       = ::std::chrono::system_clock::time_point;
+    using timer_node_t = ::beman::net::detail::context_base::resume_at_operation;
+
+    struct get_time {
+        auto operator()(auto* t) const -> time_t { return ::std::get<0>(*t); }
+    };
+    using timer_priority_t =
+        ::beman::net::detail::sorted_list<timer_node_t, ::std::less<>, get_time>;
+
+    // ------------------------------------------------------------------
+    // RAII Winsock initialisation
+    // ------------------------------------------------------------------
+    struct wsa_guard {
+        wsa_guard() {
+            ::WSADATA wd{};
+            if (::WSAStartup(MAKEWORD(2, 2), &wd) != 0)
+                throw ::std::system_error(::WSAGetLastError(),
+                                          ::std::system_category(),
+                                          "WSAStartup failed");
+        }
+        ~wsa_guard() { ::WSACleanup(); }
+        wsa_guard(const wsa_guard&)            = delete;
+        wsa_guard& operator=(const wsa_guard&) = delete;
+    } d_wsa; // constructed first, destroyed last
+
+    // ------------------------------------------------------------------
+    // State
+    // ------------------------------------------------------------------
+    ::HANDLE                                                             d_iocp{INVALID_HANDLE_VALUE};
+    ::beman::net::detail::container<::beman::net::detail::iocp_record>  d_sockets;
+    timer_priority_t                                                     d_timeouts;
+    ::beman::net::detail::context_base::task*                            d_tasks{nullptr};
+
+    // ------------------------------------------------------------------
+    // Internal helpers
+    // ------------------------------------------------------------------
+
+    auto socket_of(::beman::net::detail::socket_id id) -> ::SOCKET {
+        return this->d_sockets[id].socket;
+    }
+
+    auto associate(::SOCKET s) -> bool {
+        return ::CreateIoCompletionPort(reinterpret_cast<HANDLE>(s),
+                                        this->d_iocp, 0, 0) != nullptr;
+    }
+
+    static auto make_op(::beman::net::detail::io_base* base,
+                        ::beman::net::detail::iocp_op_kind kind)
+        -> ::beman::net::detail::iocp_op* {
+        return new ::beman::net::detail::iocp_op(base, kind);
+    }
+
+    auto iocp_timeout_ms(const time_t& now) noexcept -> ::DWORD {
+        if (this->d_timeouts.empty())
+            return INFINITE;
+        auto next = ::std::get<0>(*this->d_timeouts.front());
+        if (next <= now)
+            return 0;
+        auto ms = ::std::chrono::duration_cast<::std::chrono::milliseconds>(
+                      next - now).count();
+        return static_cast<::DWORD>(ms < 0 ? 0 : ms);
+    }
+
+    auto process_task() -> ::std::size_t {
+        if (!this->d_tasks) return 0u;
+        auto* tsk     = this->d_tasks;
+        this->d_tasks = tsk->next;
+        tsk->complete();
+        return 1u;
+    }
+
+    auto process_timeout(const time_t& now) -> ::std::size_t {
+        if (!this->d_timeouts.empty() &&
+            ::std::get<0>(*this->d_timeouts.front()) <= now) {
+            this->d_timeouts.pop_front()->complete();
+            return 1u;
+        }
+        return 0u;
+    }
+
+    static auto load_accept_ex(::SOCKET s) noexcept -> ::LPFN_ACCEPTEX {
+        ::LPFN_ACCEPTEX fn = nullptr;
+        ::GUID guid        = WSAID_ACCEPTEX;
+        ::DWORD n          = 0;
+        ::WSAIoctl(s, SIO_GET_EXTENSION_FUNCTION_POINTER,
+                   &guid, sizeof(guid), &fn, sizeof(fn), &n, nullptr, nullptr);
+        return fn;
+    }
+
+    static auto load_connect_ex(::SOCKET s) noexcept -> ::LPFN_CONNECTEX {
+        ::LPFN_CONNECTEX fn = nullptr;
+        ::GUID guid         = WSAID_CONNECTEX;
+        ::DWORD n           = 0;
+        ::WSAIoctl(s, SIO_GET_EXTENSION_FUNCTION_POINTER,
+                   &guid, sizeof(guid), &fn, sizeof(fn), &n, nullptr, nullptr);
+        return fn;
+    }
+
+    // Bind to INADDR_ANY:0 if the socket has not been bound yet.
+    // ConnectEx requires a prior bind.
+    auto ensure_bound(::beman::net::detail::socket_id id) -> bool {
+        auto& rec = this->d_sockets[id];
+        if (rec.bound) return true;
+        ::sockaddr_in addr{};
+        addr.sin_family      = AF_INET;
+        addr.sin_addr.s_addr = INADDR_ANY;
+        addr.sin_port        = 0;
+        if (::bind(rec.socket, reinterpret_cast<::sockaddr*>(&addr),
+                   sizeof(addr)) == SOCKET_ERROR)
+            return false;
+        rec.bound = true;
+        return true;
+    }
+
+    // Dispatch a completion to the appropriate io_base.
+    // bytes is the number of bytes transferred (for receive / send).
+    auto dispatch(::beman::net::detail::iocp_op* op,
+                  ::DWORD                        bytes,
+                  bool                           ok) -> void {
+        auto* base = op->base;
+        auto  kind = op->kind;
+        delete op;
+
+        if (!ok) {
+            base->error(::std::error_code(static_cast<int>(::GetLastError()),
+                                          ::std::system_category()));
+            return;
+        }
+
+        switch (kind) {
+        case ::beman::net::detail::iocp_op_kind::receive: {
+            auto* cmp = static_cast<receive_operation*>(base);
+            ::std::get<2>(*cmp) = static_cast<::std::size_t>(bytes);
+            cmp->complete();
+            break;
+        }
+        case ::beman::net::detail::iocp_op_kind::send: {
+            auto* cmp = static_cast<send_operation*>(base);
+            ::std::get<2>(*cmp) = static_cast<::std::size_t>(bytes);
+            cmp->complete();
+            break;
+        }
+        case ::beman::net::detail::iocp_op_kind::accept:
+        case ::beman::net::detail::iocp_op_kind::connect:
+            // accept and connect set up a work callback that finalises the
+            // operation; invoke it now that the kernel part is done.
+            base->work(*this, base);
+            break;
+        case ::beman::net::detail::iocp_op_kind::timer:
+            base->complete();
+            break;
+        }
+    }
+
+  public:
+    // ------------------------------------------------------------------
+    // Constructor / destructor
+    // ------------------------------------------------------------------
+
+    iocp_context() {
+        this->d_iocp = ::CreateIoCompletionPort(INVALID_HANDLE_VALUE,
+                                                 nullptr, 0, 1);
+        if (!this->d_iocp || this->d_iocp == INVALID_HANDLE_VALUE)
+            throw ::std::system_error(static_cast<int>(::GetLastError()),
+                                      ::std::system_category(),
+                                      "CreateIoCompletionPort failed");
+    }
+
+    ~iocp_context() override {
+        if (this->d_iocp && this->d_iocp != INVALID_HANDLE_VALUE)
+            ::CloseHandle(this->d_iocp);
+    }
+
+    // ------------------------------------------------------------------
+    // context_base – socket management
+    // ------------------------------------------------------------------
+
+    auto make_socket(int fd) -> ::beman::net::detail::socket_id override {
+        ::SOCKET s = static_cast<::SOCKET>(fd);
+        this->associate(s);
+        return this->d_sockets.insert(::beman::net::detail::iocp_record(s));
+    }
+
+    auto make_socket(int domain, int type, int protocol,
+                     ::std::error_code& error)
+        -> ::beman::net::detail::socket_id override {
+        // WSA_FLAG_OVERLAPPED is required for IOCP.
+        ::SOCKET s = ::WSASocketW(domain, type, protocol,
+                                   nullptr, 0, WSA_FLAG_OVERLAPPED);
+        if (s == INVALID_SOCKET) {
+            error = ::std::error_code(::WSAGetLastError(),
+                                      ::std::system_category());
+            return ::beman::net::detail::socket_id::invalid;
+        }
+        if (!this->associate(s)) {
+            error = ::std::error_code(static_cast<int>(::GetLastError()),
+                                      ::std::system_category());
+            ::closesocket(s);
+            return ::beman::net::detail::socket_id::invalid;
+        }
+        return this->d_sockets.insert(::beman::net::detail::iocp_record(s));
+    }
+
+    auto release(::beman::net::detail::socket_id id,
+                 ::std::error_code& error) -> void override {
+        ::SOCKET s = this->socket_of(id);
+        this->d_sockets.erase(id);
+        if (::closesocket(s) == SOCKET_ERROR)
+            error = ::std::error_code(::WSAGetLastError(),
+                                      ::std::system_category());
+    }
+
+    auto native_handle(::beman::net::detail::socket_id id)
+        -> ::beman::net::detail::native_handle_type override {
+        return static_cast<::beman::net::detail::native_handle_type>(
+            this->socket_of(id));
+    }
+
+    auto set_option(::beman::net::detail::socket_id id,
+                    int level, int name,
+                    const void* data, ::socklen_t size,
+                    ::std::error_code& error) -> void override {
+        if (::setsockopt(this->socket_of(id), level, name,
+                         static_cast<const char*>(data), size) == SOCKET_ERROR)
+            error = ::std::error_code(::WSAGetLastError(),
+                                      ::std::system_category());
+    }
+
+    auto bind(::beman::net::detail::socket_id id,
+              const ::beman::net::detail::endpoint& ep,
+              ::std::error_code& error) -> void override {
+        if (::bind(this->socket_of(id), ep.data(), ep.size()) == SOCKET_ERROR) {
+            error = ::std::error_code(::WSAGetLastError(),
+                                      ::std::system_category());
+            return;
+        }
+        this->d_sockets[id].bound = true;
+    }
+
+    auto listen(::beman::net::detail::socket_id id, int backlog,
+                ::std::error_code& error) -> void override {
+        if (::listen(this->socket_of(id), backlog) == SOCKET_ERROR)
+            error = ::std::error_code(::WSAGetLastError(),
+                                      ::std::system_category());
+    }
+
+    // ------------------------------------------------------------------
+    // context_base – event loop
+    // ------------------------------------------------------------------
+
+    auto run_one() -> ::std::size_t override {
+        auto now = ::std::chrono::system_clock::now();
+
+        if (0u < this->process_timeout(now) || 0u < this->process_task())
+            return 1u;
+
+        if (this->d_timeouts.empty() && !this->d_tasks)
+            return ::std::size_t{};
+
+        while (true) {
+            now = ::std::chrono::system_clock::now();
+            ::DWORD     timeout_ms = this->iocp_timeout_ms(now);
+            ::DWORD     bytes      = 0;
+            ::ULONG_PTR key        = 0;
+            OVERLAPPED* ov         = nullptr;
+
+            ::BOOL ok = ::GetQueuedCompletionStatus(
+                this->d_iocp, &bytes, &key, &ov, timeout_ms);
+
+            if (ov == nullptr) {
+                // Timeout or wakeup with no real completion.
+                if (0u < this->process_timeout(
+                        ::std::chrono::system_clock::now()))
+                    return 1u;
+                if (0u < this->process_task())
+                    return 1u;
+                return ::std::size_t{};
+            }
+
+            // Recover our wrapper from the OVERLAPPED pointer.
+            // Safe because OVERLAPPED is the first member of iocp_op.
+            auto* op = reinterpret_cast<::beman::net::detail::iocp_op*>(ov);
+            this->dispatch(op, bytes, ok == TRUE);
+            return 1u;
+        }
+    }
+
+    auto wakeup() -> void {
+        // Post a no-op completion to unblock a waiting thread.
+        ::PostQueuedCompletionStatus(this->d_iocp, 0, 0, nullptr);
+    }
+
+    auto schedule(::beman::net::detail::context_base::task* tsk)
+        -> void override {
+        tsk->next     = this->d_tasks;
+        this->d_tasks = tsk;
+        this->wakeup();
+    }
+
+    auto cancel(::beman::net::detail::io_base* cancel_op,
+                ::beman::net::detail::io_base* op) -> void override {
+        // CancelIoEx cancels all pending I/O on the socket.
+        // Fine-grained per-operation cancel would require tracking each
+        // OVERLAPPED pointer separately. -dk:TODO
+        ::CancelIoEx(
+            reinterpret_cast<::HANDLE>(this->socket_of(op->id)), nullptr);
+        op->cancel();
+        cancel_op->cancel();
+    }
+
+    // ------------------------------------------------------------------
+    // context_base – async operations
+    // ------------------------------------------------------------------
+
+    auto accept(::beman::net::detail::context_base::accept_operation* completion)
+        -> ::beman::net::detail::submit_result override {
+
+        ::SOCKET listen_sock = this->socket_of(completion->id);
+
+        // Determine address family from the listening socket.
+        ::WSAPROTOCOL_INFOW info{};
+        int info_len = sizeof(info);
+        if (::getsockopt(listen_sock, SOL_SOCKET, SO_PROTOCOL_INFOW,
+                         reinterpret_cast<char*>(&info),
+                         &info_len) == SOCKET_ERROR) {
+            completion->error(::std::error_code(::WSAGetLastError(),
+                                                ::std::system_category()));
+            return ::beman::net::detail::submit_result::error;
+        }
+
+        // AcceptEx requires the accept socket to exist before the call.
+        ::SOCKET accept_sock = ::WSASocketW(info.iAddressFamily,
+                                             info.iSocketType,
+                                             info.iProtocol,
+                                             nullptr, 0, WSA_FLAG_OVERLAPPED);
+        if (accept_sock == INVALID_SOCKET) {
+            completion->error(::std::error_code(::WSAGetLastError(),
+                                                ::std::system_category()));
+            return ::beman::net::detail::submit_result::error;
+        }
+
+        ::LPFN_ACCEPTEX fn = load_accept_ex(listen_sock);
+        if (!fn) {
+            ::closesocket(accept_sock);
+            completion->error(::std::error_code(::WSAGetLastError(),
+                                                ::std::system_category()));
+            return ::beman::net::detail::submit_result::error;
+        }
+
+        // AcceptEx address buffer: two sockaddr_storage entries each padded
+        // by 16 bytes, plus zero bytes of receive data.
+        static constexpr ::DWORD addr_buf_size =
+            sizeof(::sockaddr_storage) + 16;
+        auto* buf = new char[2 * addr_buf_size];
+
+        auto*  op       = make_op(completion, ::beman::net::detail::iocp_op_kind::accept);
+        ::DWORD bytes_rx = 0;
+
+        ::BOOL ok = fn(listen_sock, accept_sock, buf,
+                        0,              // dwReceiveDataLength
+                        addr_buf_size,
+                        addr_buf_size,
+                        &bytes_rx,
+                        &op->overlapped);
+
+        if (!ok && ::WSAGetLastError() != ERROR_IO_PENDING) {
+            delete[] buf;
+            delete op;
+            ::closesocket(accept_sock);
+            completion->error(::std::error_code(::WSAGetLastError(),
+                                                ::std::system_category()));
+            return ::beman::net::detail::submit_result::error;
+        }
+
+        // Store accept_sock + address buffer in io_base::extra so they
+        // survive until the IOCP completion arrives.
+        struct accept_state {
+            ::SOCKET accept_sock;
+            char*    buf;
+        };
+        completion->extra = {
+            new accept_state{accept_sock, buf},
+            +[](void* p) {
+                auto* st = static_cast<accept_state*>(p);
+                // If still valid at destruction time, close the socket.
+                // Normally ownership is transferred to make_socket before
+                // this deleter runs.
+                if (st->accept_sock != INVALID_SOCKET)
+                    ::closesocket(st->accept_sock);
+                delete[] st->buf;
+                delete st;
+            }};
+
+        // Set up the work callback that will be invoked by dispatch()
+        // once the kernel signals the accept completion.
+        completion->work = [](::beman::net::detail::context_base& ctx,
+                               ::beman::net::detail::io_base*     base)
+            -> ::beman::net::detail::submit_result {
+            auto& iocp_ctx = static_cast<iocp_context&>(ctx);
+            auto* cmp      = static_cast<accept_operation*>(base);
+            auto* st =
+                static_cast<accept_state*>(cmp->extra.get());
+
+            // Update the accept socket to inherit the listener's properties.
+            ::SOCKET listen_s = iocp_ctx.socket_of(cmp->id);
+            ::setsockopt(st->accept_sock,
+                         SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT,
+                         reinterpret_cast<char*>(&listen_s), sizeof(::SOCKET));
+
+            // Transfer ownership of the accept socket to the context.
+            ::SOCKET accepted       = st->accept_sock;
+            st->accept_sock         = INVALID_SOCKET; // prevent double-close
+            ::std::get<2>(*cmp)     = iocp_ctx.make_socket(
+                static_cast<int>(accepted));
+
+            cmp->extra.reset(); // release accept_state
+            cmp->complete();
+            return ::beman::net::detail::submit_result::ready;
+        };
+
+        return ::beman::net::detail::submit_result::submit;
+    }
+
+    // ------------------------------------------------------------------
+
+    auto connect(::beman::net::detail::context_base::connect_operation* op)
+        -> ::beman::net::detail::submit_result override {
+
+        ::SOCKET s = this->socket_of(op->id);
+
+        if (!this->ensure_bound(op->id)) {
+            op->error(::std::error_code(::WSAGetLastError(),
+                                        ::std::system_category()));
+            return ::beman::net::detail::submit_result::error;
+        }
+
+        ::LPFN_CONNECTEX fn = load_connect_ex(s);
+        if (!fn) {
+            op->error(::std::error_code(::WSAGetLastError(),
+                                        ::std::system_category()));
+            return ::beman::net::detail::submit_result::error;
+        }
+
+        const auto& ep       = ::std::get<0>(*op);
+        auto*       iocp_op_ = make_op(op, ::beman::net::detail::iocp_op_kind::connect);
+        ::DWORD     bytes_sent = 0;
+
+        ::BOOL ok = fn(s, ep.data(), ep.size(),
+                        nullptr, 0, &bytes_sent,
+                        &iocp_op_->overlapped);
+
+        if (!ok && ::WSAGetLastError() != ERROR_IO_PENDING) {
+            delete iocp_op_;
+            op->error(::std::error_code(::WSAGetLastError(),
+                                        ::std::system_category()));
+            return ::beman::net::detail::submit_result::error;
+        }
+
+        // After ConnectEx completes, SO_UPDATE_CONNECT_CONTEXT is required
+        // before the socket can be used for send / receive.
+        op->work = [](::beman::net::detail::context_base& ctx,
+                       ::beman::net::detail::io_base*     base)
+            -> ::beman::net::detail::submit_result {
+            auto& iocp_ctx = static_cast<iocp_context&>(ctx);
+            ::setsockopt(iocp_ctx.socket_of(base->id),
+                         SOL_SOCKET, SO_UPDATE_CONNECT_CONTEXT,
+                         nullptr, 0);
+            base->complete();
+            return ::beman::net::detail::submit_result::ready;
+        };
+
+        return ::beman::net::detail::submit_result::submit;
+    }
+
+    // ------------------------------------------------------------------
+
+    auto receive(::beman::net::detail::context_base::receive_operation* op)
+        -> ::beman::net::detail::submit_result override {
+
+        auto& rec    = this->d_sockets[op->id];
+        auto* iocp_op_ = make_op(op, ::beman::net::detail::iocp_op_kind::receive);
+
+        ::msghdr* msg   = &::std::get<0>(*op);
+        ::DWORD   flags = static_cast<::DWORD>(::std::get<1>(*op));
+        ::DWORD   bytes = 0;
+        int       rc    = SOCKET_ERROR;
+
+        ::LPFN_WSARECVMSG pfn = rec.get_recv_msg();
+        if (pfn) {
+            // Use WSARecvMsg for full scatter-gather + ancillary data support.
+            ::WSABUF bufs[16];
+            ::ULONG  n  = (msg->msg_iovlen < 16) ? msg->msg_iovlen : 16;
+            ::WSAMSG wm = msg->to_wsamsg(bufs, n);
+            rc = pfn(rec.socket, &wm, &bytes, &iocp_op_->overlapped, nullptr);
+        } else {
+            // Fallback to plain WSARecv.
+            ::WSABUF bufs[16];
+            ::ULONG  n = (msg->msg_iovlen < 16) ? msg->msg_iovlen : 16;
+            for (::ULONG i = 0; i < n; ++i)
+                bufs[i] = static_cast<::WSABUF>(msg->msg_iov[i]);
+            rc = ::WSARecv(rec.socket, bufs, n,
+                           &bytes, &flags,
+                           &iocp_op_->overlapped, nullptr);
+        }
+
+        if (rc == SOCKET_ERROR && ::WSAGetLastError() != WSA_IO_PENDING) {
+            delete iocp_op_;
+            op->error(::std::error_code(::WSAGetLastError(),
+                                        ::std::system_category()));
+            return ::beman::net::detail::submit_result::error;
+        }
+
+        return ::beman::net::detail::submit_result::submit;
+    }
+
+    // ------------------------------------------------------------------
+
+    auto send(::beman::net::detail::context_base::send_operation* op)
+        -> ::beman::net::detail::submit_result override {
+
+        auto& rec    = this->d_sockets[op->id];
+        auto* iocp_op_ = make_op(op, ::beman::net::detail::iocp_op_kind::send);
+
+        ::msghdr* msg   = &::std::get<0>(*op);
+        ::DWORD   bytes = 0;
+        int       rc    = SOCKET_ERROR;
+
+        ::LPFN_WSASENDMSG pfn = rec.get_send_msg();
+        if (pfn) {
+            ::WSABUF bufs[16];
+            ::ULONG  n  = (msg->msg_iovlen < 16) ? msg->msg_iovlen : 16;
+            ::WSAMSG wm = msg->to_wsamsg(bufs, n);
+            rc = pfn(rec.socket, &wm, 0, &bytes,
+                     &iocp_op_->overlapped, nullptr);
+        } else {
+            ::WSABUF bufs[16];
+            ::ULONG  n = (msg->msg_iovlen < 16) ? msg->msg_iovlen : 16;
+            for (::ULONG i = 0; i < n; ++i)
+                bufs[i] = static_cast<::WSABUF>(msg->msg_iov[i]);
+            rc = ::WSASend(rec.socket, bufs, n,
+                           &bytes, 0,
+                           &iocp_op_->overlapped, nullptr);
+        }
+
+        if (rc == SOCKET_ERROR && ::WSAGetLastError() != WSA_IO_PENDING) {
+            delete iocp_op_;
+            op->error(::std::error_code(::WSAGetLastError(),
+                                        ::std::system_category()));
+            return ::beman::net::detail::submit_result::error;
+        }
+
+        return ::beman::net::detail::submit_result::submit;
+    }
+
+    // ------------------------------------------------------------------
+
+    auto resume_at(::beman::net::detail::context_base::resume_at_operation* op)
+        -> ::beman::net::detail::submit_result override {
+        if (::std::chrono::system_clock::now() < ::std::get<0>(*op)) {
+            this->d_timeouts.insert(op);
+            return ::beman::net::detail::submit_result::submit;
+        }
+        op->complete();
+        return ::beman::net::detail::submit_result::ready;
+    }
+};
+
+// ----------------------------------------------------------------------------
+
+#endif // _MSC_VER
+#endif // INCLUDED_BEMAN_NET_DETAIL_IOCP_CONTEXT

--- a/include/beman/net/detail/iocp_context.hpp
+++ b/include/beman/net/detail/iocp_context.hpp
@@ -569,7 +569,15 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
         op->work = [](::beman::net::detail::context_base& ctx,
                       ::beman::net::detail::io_base*      base) -> ::beman::net::detail::submit_result {
             auto& iocp_ctx = static_cast<iocp_context&>(ctx);
-            ::setsockopt(iocp_ctx.socket_of(base->id), SOL_SOCKET, SO_UPDATE_CONNECT_CONTEXT, nullptr, 0);
+
+            // Explicitly cast nullptr to const char* to avoid an ambiguous overload (C2668).
+            // platform.hpp provides a POSIX-compatible setsockopt taking const void*, which
+            // conflicts with the native Winsock version (const char*) when passing nullptr.
+            ::setsockopt(iocp_ctx.socket_of(base->id),
+                         SOL_SOCKET,
+                         SO_UPDATE_CONNECT_CONTEXT,
+                         static_cast<const char*>(nullptr),
+                         0);
             base->complete();
             return ::beman::net::detail::submit_result::ready;
         };

--- a/include/beman/net/detail/iocp_context.hpp
+++ b/include/beman/net/detail/iocp_context.hpp
@@ -148,22 +148,6 @@ struct beman::net::detail::iocp_record {
 // ----------------------------------------------------------------------------
 
 struct beman::net::detail::iocp_context final : ::beman::net::detail::context_base {
-#ifdef _MSC_VER
-    // On Windows, Winsock must be initialised before any socket call.
-    // This RAII guard calls WSAStartup on construction and WSACleanup on
-    // destruction, tying the Winsock lifetime to the poll_context object.
-    struct wsa_guard {
-        wsa_guard() {
-            ::WSADATA wd{};
-            if (::WSAStartup(MAKEWORD(2, 2), &wd) != 0)
-                throw ::std::system_error(::WSAGetLastError(), ::std::system_category(), "WSAStartup failed");
-        }
-        ~wsa_guard() { ::WSACleanup(); }
-        wsa_guard(const wsa_guard&)            = delete;
-        wsa_guard& operator=(const wsa_guard&) = delete;
-    } d_wsa; // constructed first, destroyed last
-#endif
-
   private:
     // ------------------------------------------------------------------
     // Types

--- a/include/beman/net/detail/iocp_context.hpp
+++ b/include/beman/net/detail/iocp_context.hpp
@@ -86,7 +86,7 @@ namespace beman::net::detail {
 enum class iocp_op_kind : unsigned char { accept, connect, receive, send, timer };
 
 struct iocp_op {
-    OVERLAPPED   overlapped{}; // MUST be first – reinterpret_cast relies on it
+    OVERLAPPED   overlapped{}; // MUST be first - reinterpret_cast relies on it
     io_base*     base{nullptr};
     iocp_op_kind kind{};
 
@@ -311,7 +311,7 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
     }
 
     // ------------------------------------------------------------------
-    // context_base – socket management
+    // context_base - socket management
     // ------------------------------------------------------------------
 
     auto make_socket(int fd) -> ::beman::net::detail::socket_id override {
@@ -372,7 +372,7 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
     }
 
     // ------------------------------------------------------------------
-    // context_base – event loop
+    // context_base - event loop
     // ------------------------------------------------------------------
 
     auto run_one() -> ::std::size_t override {
@@ -431,7 +431,7 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
     }
 
     // ------------------------------------------------------------------
-    // context_base – async operations
+    // context_base - async operations
     // ------------------------------------------------------------------
 
     auto accept(::beman::net::detail::context_base::accept_operation* completion)

--- a/include/beman/net/detail/iocp_context.hpp
+++ b/include/beman/net/detail/iocp_context.hpp
@@ -126,7 +126,7 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
     using timer_priority_t = ::beman::net::detail::sorted_list<timer_node_t, ::std::less<>, get_time>;
 
     // ------------------------------------------------------------------
-    // RAII Winsock initialisation
+    // RAII Winsock initialization
     // ------------------------------------------------------------------
     struct wsa_guard {
         wsa_guard() {

--- a/include/beman/net/detail/iocp_context.hpp
+++ b/include/beman/net/detail/iocp_context.hpp
@@ -102,8 +102,8 @@ struct iocp_op {
 // ----------------------------------------------------------------------------
 
 struct beman::net::detail::iocp_record {
-    ::SOCKET          socket{INVALID_SOCKET};
-    bool              bound{false};
+    ::SOCKET socket{INVALID_SOCKET};
+    bool     bound{false};
 
     explicit iocp_record(::SOCKET s) : socket(s) {}
 };
@@ -147,32 +147,18 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
     timer_priority_t                                                   d_timeouts;
     ::beman::net::detail::context_base::task*                          d_tasks{nullptr};
 
-    //Record the number of asynchronous I/O operations submitted to the kernel.
-    ::std::size_t                                                      d_outstanding_io{0};
+    // Record the number of asynchronous I/O operations submitted to the kernel.
+    ::std::size_t d_outstanding_io{0};
 
-    //Keep track of the number of currently active sockets to prevent the event loop from terminating prematurely
-    ::std::size_t                                                      d_socket_count{0};
-
-    // Helper: change d_outstanding_io with logging
-    auto inc_outstanding(const char* reason) -> void {
-        ++this->d_outstanding_io;
-        ::std::cout << "[iocp] outstanding++ (" << reason << ") -> " << this->d_outstanding_io << "\n";
-    }
-    auto dec_outstanding(const char* reason) -> void {
-        --this->d_outstanding_io;
-        ::std::cout << "[iocp] outstanding-- (" << reason << ") -> " << this->d_outstanding_io << "\n";
-    }
+    // Keep track of the number of currently active sockets to prevent the event loop from terminating prematurely
+    ::std::size_t d_socket_count{0};
 
     struct deferred_io_task : context_base::task {
         iocp_context* ctx;
         io_base*      base;
         ::DWORD       bytes;
-        deferred_io_task(iocp_context* c, io_base* b, ::DWORD by)
-            : ctx(c), base(b), bytes(by) {
-            ctx->inc_outstanding("deferred_io_task ctor");
-        }
+        deferred_io_task(iocp_context* c, io_base* b, ::DWORD by) : ctx(c), base(b), bytes(by) {}
         auto complete() -> void override {
-            ctx->dec_outstanding("deferred_io_task::complete");
             ctx->m_current_bytes = this->bytes;
             ctx->m_current_error = 0;
             if (this->base->work)
@@ -183,8 +169,8 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
 
   public:
     // Used to temporarily store the system state for the Lambda closure after run_one() parsing completes
-    ::DWORD                                                            m_current_bytes{0};
-    int                                                                m_current_error{0};  
+    ::DWORD m_current_bytes{0};
+    int     m_current_error{0};
 
     // ------------------------------------------------------------------
     // Internal helpers
@@ -200,9 +186,7 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
         // This prevents double-completion: our deferred_io_task handles rc==0,
         // and without this flag the kernel would also post a completion for the
         // same iocp_op we already deleted, causing a use-after-free crash.
-        ::SetFileCompletionNotificationModes(
-            reinterpret_cast<HANDLE>(s),
-            FILE_SKIP_COMPLETION_PORT_ON_SUCCESS);
+        ::SetFileCompletionNotificationModes(reinterpret_cast<HANDLE>(s), FILE_SKIP_COMPLETION_PORT_ON_SUCCESS);
         return true;
     }
 
@@ -226,10 +210,7 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
             return 0u;
         auto* tsk     = this->d_tasks;
         this->d_tasks = tsk->next;
-        ::std::cout << "[iocp] process_task() executing task\n";
         tsk->complete();
-        ::std::cout << "[iocp] process_task() task done, outstanding=" 
-                    << this->d_outstanding_io << " sockets=" << this->d_socket_count << "\n";
         return 1u;
     }
 
@@ -276,28 +257,14 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
     // Dispatch a completion to the appropriate io_base.
     // bytes is the number of bytes transferred (for receive / send).
     auto dispatch(::beman::net::detail::iocp_op* op, ::DWORD bytes, bool ok) -> void {
-        auto* base = op->base;
+        auto* base            = op->base;
         this->m_current_bytes = bytes;
         this->m_current_error = ok ? 0 : static_cast<int>(::GetLastError());
 
         delete op;
-        dec_outstanding("dispatch (IOCP completion)");
 
         if (base->work) {
-            ::std::cout << "[iocp] dispatch calling work, bytes=" << bytes 
-                        << " err=" << this->m_current_error << "\n";
-            ::std::cout.flush();
-            try {
-                base->work(*this, base);
-            } catch (const std::exception& e) {
-                ::std::cout << "[iocp] dispatch work threw exception: " << e.what() << "\n";
-                ::std::cout.flush();
-            } catch (...) {
-                ::std::cout << "[iocp] dispatch work threw unknown exception\n";
-                ::std::cout.flush();
-            }
-            ::std::cout << "[iocp] dispatch work returned\n";
-            ::std::cout.flush();
+            base->work(*this, base);
         } else {
             // 没有 work 回调（如 timer），直接处理
             if (!ok && this->m_current_error == ERROR_OPERATION_ABORTED) {
@@ -308,7 +275,6 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
                 base->complete();
             }
         }
-
     }
 
     // Stored in io_base::extra for the duration of an AcceptEx call.
@@ -366,9 +332,9 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
 
     // Internal overload that accepts a SOCKET directly, avoiding the int truncation.
     auto make_socket_from_handle(::SOCKET s) -> ::beman::net::detail::socket_id {
-         this->associate(s);
-         ++this->d_socket_count;
-         return this->d_sockets.insert(::beman::net::detail::iocp_record(s));
+        this->associate(s);
+        ++this->d_socket_count;
+        return this->d_sockets.insert(::beman::net::detail::iocp_record(s));
     }
 
     auto release(::beman::net::detail::socket_id id, ::std::error_code& error) -> void override {
@@ -378,8 +344,6 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
             error = ::std::error_code(::WSAGetLastError(), ::std::system_category());
 
         --this->d_socket_count;
-        ::std::cout << "[iocp] release() socket_count -> " << this->d_socket_count 
-                    << " outstanding=" << this->d_outstanding_io << "\n";
     }
 
     auto native_handle(::beman::net::detail::socket_id id) -> ::beman::net::detail::native_handle_type override {
@@ -416,18 +380,12 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
 
     auto run_one() -> ::std::size_t override {
 
-        ::std::cout << "[iocp] run_one() called, outstanding=" 
-                    << this->d_outstanding_io 
-                    << " sockets=" << this->d_socket_count << "\n";
         auto now = ::std::chrono::system_clock::now();
 
         if (0u < this->process_timeout(now) || 0u < this->process_task())
             return 1u;
 
-        if (this->d_timeouts.empty() && !this->d_tasks && this->d_outstanding_io == 0 && this->d_socket_count == 0)
-        {
-            ::std::cout << "[iocp] run_one returning 0 (top-check): outstanding=" 
-                        << this->d_outstanding_io << " sockets=" << this->d_socket_count << "\n";
+        if (this->d_timeouts.empty() && !this->d_tasks && this->d_outstanding_io == 0 && this->d_socket_count == 0) {
             return ::std::size_t{};
         }
 
@@ -439,35 +397,24 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
             OVERLAPPED* ov         = nullptr;
 
             ::BOOL ok = ::GetQueuedCompletionStatus(this->d_iocp, &bytes, &key, &ov, timeout_ms);
-            ::std::cout << "[iocp] GQCS returned ok=" << ok 
-                        << " ov=" << (void*)ov 
-                        << " bytes=" << bytes 
-                        << " err=" << ::GetLastError() << "\n";
             if (ov == nullptr) {
                 // Timeout or wakeup with no real completion.
                 if (0u < this->process_timeout(::std::chrono::system_clock::now()))
                     return 1u;
                 if (0u < this->process_task())
                     return 1u;
-                ::std::cout << "[iocp] run_one returning 0 via ov==nullptr, outstanding=" << this->d_outstanding_io << "\n";
-                
-                if (this->d_timeouts.empty() && !this->d_tasks && this->d_outstanding_io == 0 && this->d_socket_count == 0) 
-                {
-                    ::std::cout << "[iocp] run_one returning 0 (ov==nullptr): outstanding="
-                                << this->d_outstanding_io << " sockets=" << this->d_socket_count << "\n";
+
+                if (this->d_timeouts.empty() && !this->d_tasks && this->d_outstanding_io == 0 &&
+                    this->d_socket_count == 0) {
                     return ::std::size_t{};
                 }
 
                 continue;
-               // return ::std::size_t{};
             }
 
             // Recover our wrapper from the OVERLAPPED pointer.
             // Safe because OVERLAPPED is the first member of iocp_op.
             auto* op = reinterpret_cast<::beman::net::detail::iocp_op*>(ov);
-            ::std::cout << "[iocp] dispatching ov=" << (void*)ov 
-                        << " kind=" << static_cast<int>(op->kind)
-                        << " base=" << (void*)op->base << "\n";
             this->dispatch(op, bytes, ok == TRUE);
             return 1u;
         }
@@ -480,37 +427,23 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
 
     auto schedule(::beman::net::detail::context_base::task* tsk) -> void override {
         bool was_empty = (this->d_tasks == nullptr);
-        tsk->next     = this->d_tasks;
-        this->d_tasks = tsk;
-        //this->wakeup();
-        /*
-        if(was_empty)
-        {
-            this->wakeup();
-        }
-        */
+        tsk->next      = this->d_tasks;
+        this->d_tasks  = tsk;
     }
 
     auto cancel(::beman::net::detail::io_base* cancel_op, ::beman::net::detail::io_base* op) -> void override {
-        if (op->id == ::beman::net::detail::socket_id::invalid) 
-        {
+        if (op->id == ::beman::net::detail::socket_id::invalid) {
             // Timer: remove from queue and cancel synchronously
-            ::std::cout << "[iocp] cancel() timer op\n";
             this->d_timeouts.erase(static_cast<timer_node_t*>(op));
             op->cancel();
         } else {
             // Socket IO: async cancel, wait for ERROR_OPERATION_ABORTED from IOCP
-            ::std::cout << "[iocp] cancel() socket io op, calling CancelIoEx\n";
             ::SOCKET s = this->socket_of(op->id);
-            if (s != INVALID_SOCKET) 
-            {
+            if (s != INVALID_SOCKET) {
                 ::CancelIoEx(reinterpret_cast<::HANDLE>(s), nullptr);
             }
         }
-        ::std::cout << "[iocp] cancel() calling cancel_op->cancel()\n";
         cancel_op->cancel();
-        ::std::cout << "[iocp] cancel() done, outstanding=" << this->d_outstanding_io 
-                    << " sockets=" << this->d_socket_count << "\n";
     }
 
     // ------------------------------------------------------------------
@@ -519,9 +452,6 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
 
     auto accept(::beman::net::detail::context_base::accept_operation* completion)
         -> ::beman::net::detail::submit_result override {
-
-        ::std::cout << "[iocp] accept() called, d_outstanding_io=" << this->d_outstanding_io << "\n";
-        ::std::cout << "[iocp] AcceptEx submitted\n";
 
         ::SOCKET listen_sock = this->socket_of(completion->id);
 
@@ -559,8 +489,6 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
         // once the kernel signals the accept completion.
         completion->work = [](::beman::net::detail::context_base& ctx,
                               ::beman::net::detail::io_base*      base) -> ::beman::net::detail::submit_result {
-            ::std::cout << "[iocp] accept complete, new socket registered\n";
-
             auto& iocp_ctx = static_cast<iocp_context&>(ctx);
             auto* cmp      = static_cast<accept_operation*>(base);
             auto* st       = static_cast<accept_state*>(cmp->extra.get());
@@ -585,14 +513,10 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
             st->accept_sock     = INVALID_SOCKET; // prevent double-close
             ::std::get<2>(*cmp) = iocp_ctx.make_socket_from_handle(accepted);
 
-
             cmp->extra.reset(); // release accept_state
-            
 
-            ::std::cout << "[iocp] calling accept cmp->complete()\n";
             cmp->complete();
 
-            ::std::cout << "[iocp] after cmp->complete(), returning\n";
             return ::beman::net::detail::submit_result::ready;
         };
 
@@ -610,7 +534,6 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
                                  delete st;
                              }};
 
-
         ::BOOL ok = fn(listen_sock,
                        accept_sock,
                        buf,
@@ -619,7 +542,7 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
                        addr_buf_size,
                        &bytes_rx,
                        &op->overlapped);
-        
+
         if (!ok && ::WSAGetLastError() != ERROR_IO_PENDING) {
             delete[] buf;
             delete op;
@@ -627,8 +550,6 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
             completion->error(::std::error_code(::WSAGetLastError(), ::std::system_category()));
             return ::beman::net::detail::submit_result::error;
         }
-
-        inc_outstanding("accept submitted");
 
         return ::beman::net::detail::submit_result::submit;
     }
@@ -689,8 +610,6 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
             return ::beman::net::detail::submit_result::error;
         }
 
-        inc_outstanding("connect submitted");
-
         return ::beman::net::detail::submit_result::submit;
     }
 
@@ -704,12 +623,13 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
 
         ::msghdr* msg   = &::std::get<0>(*op);
         iocp_op_->flags = static_cast<::DWORD>(::std::get<1>(*op));
-        int       rc    = SOCKET_ERROR;
+        int rc          = SOCKET_ERROR;
 
-        op->work = [](::beman::net::detail::context_base& ctx, ::beman::net::detail::io_base* base) -> ::beman::net::detail::submit_result {
+        op->work = [](::beman::net::detail::context_base& ctx,
+                      ::beman::net::detail::io_base*      base) -> ::beman::net::detail::submit_result {
             auto& iocp = static_cast<iocp_context&>(ctx);
             auto* cmp  = static_cast<receive_operation*>(base);
-            
+
             if (iocp.m_current_error == ERROR_OPERATION_ABORTED || iocp.m_current_error == WSAECONNRESET) {
                 cmp->cancel();
                 return ::beman::net::detail::submit_result::ready;
@@ -726,28 +646,22 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
         ::WSABUF bufs[16];
         ::ULONG  n = (msg->msg_iovlen < 16) ? msg->msg_iovlen : 16;
         for (::ULONG i = 0; i < n; ++i)
-                bufs[i] = static_cast<::WSABUF>(msg->msg_iov[i]);
+            bufs[i] = static_cast<::WSABUF>(msg->msg_iov[i]);
 
-        ::DWORD bytes_sync = 0;  
+        ::DWORD bytes_sync = 0;
         rc = ::WSARecv(rec.socket, bufs, n, &bytes_sync, &iocp_op_->flags, &iocp_op_->overlapped, nullptr);
-        ::std::cout << "[iocp] WSARecv submitted rc=" << rc 
-            << " err=" << ::WSAGetLastError() << "\n";
-        
+
         if (rc == 0) {
-            ::std::cout << "[iocp] WSARecv sync complete, bytes=" << bytes_sync << ", using deferred_io_task\n";
-            delete iocp_op_; 
+            delete iocp_op_;
             this->schedule(new deferred_io_task(this, op, bytes_sync));
-            return ::beman::net::detail::submit_result::submit; 
+            return ::beman::net::detail::submit_result::submit;
         }
-        
-        
+
         if (rc == SOCKET_ERROR && ::WSAGetLastError() != WSA_IO_PENDING) {
             delete iocp_op_;
             op->error(::std::error_code(::WSAGetLastError(), ::std::system_category()));
             return ::beman::net::detail::submit_result::error;
         }
-
-        inc_outstanding("WSARecv submitted async");
 
         return ::beman::net::detail::submit_result::submit;
     }
@@ -759,10 +673,11 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
         auto& rec      = this->d_sockets[op->id];
         auto* iocp_op_ = make_op(op, ::beman::net::detail::iocp_op_kind::send);
 
-        op->work = [](::beman::net::detail::context_base& ctx, ::beman::net::detail::io_base* base) -> ::beman::net::detail::submit_result {
+        op->work = [](::beman::net::detail::context_base& ctx,
+                      ::beman::net::detail::io_base*      base) -> ::beman::net::detail::submit_result {
             auto& iocp = static_cast<iocp_context&>(ctx);
             auto* cmp  = static_cast<send_operation*>(base);
-            
+
             if (iocp.m_current_error == ERROR_OPERATION_ABORTED) {
                 cmp->cancel();
                 return ::beman::net::detail::submit_result::ready;
@@ -776,35 +691,28 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
             return ::beman::net::detail::submit_result::ready;
         };
 
-        ::msghdr* msg   = &::std::get<0>(*op);
-        int       rc    = SOCKET_ERROR;
+        ::msghdr* msg = &::std::get<0>(*op);
+        int       rc  = SOCKET_ERROR;
 
         ::WSABUF bufs[16];
         ::ULONG  n = (msg->msg_iovlen < 16) ? msg->msg_iovlen : 16;
         for (::ULONG i = 0; i < n; ++i)
-                bufs[i] = static_cast<::WSABUF>(msg->msg_iov[i]);
+            bufs[i] = static_cast<::WSABUF>(msg->msg_iov[i]);
 
- 
         ::DWORD bytes_sync = 0;
-        rc = ::WSASend(rec.socket, bufs, n, &bytes_sync, 0, &iocp_op_->overlapped, nullptr);
-        ::std::cout << "[iocp] WSASend submitted rc=" << rc
-            << " err=" << ::WSAGetLastError() << "\n";
-        
+        rc                 = ::WSASend(rec.socket, bufs, n, &bytes_sync, 0, &iocp_op_->overlapped, nullptr);
+
         if (rc == 0) {
-            ::std::cout << "[iocp] WSASend sync complete, bytes=" << bytes_sync << ", using deferred_io_task\n";
             delete iocp_op_;
             this->schedule(new deferred_io_task(this, op, bytes_sync));
             return ::beman::net::detail::submit_result::submit;
         }
-       
-        
+
         if (rc == SOCKET_ERROR && ::WSAGetLastError() != WSA_IO_PENDING) {
             delete iocp_op_;
             op->error(::std::error_code(::WSAGetLastError(), ::std::system_category()));
             return ::beman::net::detail::submit_result::error;
         }
-
-        inc_outstanding("WSASend submitted async");
 
         return ::beman::net::detail::submit_result::submit;
     }
@@ -815,7 +723,7 @@ struct beman::net::detail::iocp_context final : ::beman::net::detail::context_ba
         -> ::beman::net::detail::submit_result override {
 
         op->id = ::beman::net::detail::socket_id::invalid;
-            
+
         if (::std::chrono::system_clock::now() < ::std::get<0>(*op)) {
             this->d_timeouts.insert(op);
             return ::beman::net::detail::submit_result::submit;

--- a/include/beman/net/detail/netfwd.hpp
+++ b/include/beman/net/detail/netfwd.hpp
@@ -12,8 +12,13 @@
 namespace beman::net::detail {
 enum socket_id : ::std::uint_least32_t { invalid = ::std::numeric_limits<::std::uint_least32_t>::max() };
 struct context_base;
+#ifdef _MSC_VER
+using native_handle_type                           = ::std::uintptr_t; // SOCKET is ULONG_PTR
+inline constexpr native_handle_type invalid_handle = ::std::numeric_limits<::std::uintptr_t>::max(); // INVALID_SOCKET
+#else
 using native_handle_type = int;
 inline constexpr native_handle_type invalid_handle{-1};
+#endif
 } // namespace beman::net::detail
 
 namespace beman::net {

--- a/include/beman/net/detail/platform.hpp
+++ b/include/beman/net/detail/platform.hpp
@@ -157,29 +157,6 @@ inline int fcntl(::SOCKET s, int /*cmd*/, int flags) noexcept {
 // loaded at runtime via WSAIoctl.  We load them once (per process) on the
 // first call that provides a valid socket handle.
 
-namespace beman::net::detail::platform {
-inline ::LPFN_WSARECVMSG load_wsarecvmsg(::SOCKET s) noexcept {
-    static ::LPFN_WSARECVMSG pfn = nullptr;
-    if (!pfn) {
-        ::GUID  guid = WSAID_WSARECVMSG;
-        ::DWORD n    = 0;
-        ::WSAIoctl(
-            s, SIO_GET_EXTENSION_FUNCTION_POINTER, &guid, sizeof(guid), &pfn, sizeof(pfn), &n, nullptr, nullptr);
-    }
-    return pfn;
-}
-inline ::LPFN_WSASENDMSG load_wsasendmsg(::SOCKET s) noexcept {
-    static ::LPFN_WSASENDMSG pfn = nullptr;
-    if (!pfn) {
-        ::GUID  guid = WSAID_WSASENDMSG;
-        ::DWORD n    = 0;
-        ::WSAIoctl(
-            s, SIO_GET_EXTENSION_FUNCTION_POINTER, &guid, sizeof(guid), &pfn, sizeof(pfn), &n, nullptr, nullptr);
-    }
-    return pfn;
-}
-} // namespace beman::net::detail::platform
-
 // Maximum scatter-gather segments we support in a single recvmsg/sendmsg call.
 // Allocated on the stack inside the wrappers to avoid heap allocation.
 inline constexpr ::ULONG k_max_iov = 16;

--- a/include/beman/net/detail/platform.hpp
+++ b/include/beman/net/detail/platform.hpp
@@ -6,21 +6,238 @@
 #define INCLUDED_INCLUDE_BEMAN_NET_DETAIL_PLATFORM
 
 // ----------------------------------------------------------------------------
+// This header is the single point of platform abstraction for beman.net.
+//
+// On POSIX (Linux / macOS) it simply includes the standard system headers.
+// On Windows (MSVC) it includes WinSock2 and defines thin compatibility types
+// and wrappers so that the rest of the library can be written in POSIX style
+// without any #ifdef outside of this file.
+//
+// Types defined here for Windows:
+//   iovec      – matches POSIX iovec (iov_base / iov_len), converts to WSABUF
+//   msghdr     – matches POSIX msghdr field names, converts to WSAMSG
+//   socklen_t  – int (matches WinSock2 convention)
+//   pollfd     – alias for WSAPOLLFD
+//   nfds_t     – alias for ULONG
+//
+// Free functions defined here for Windows:
+//   sock_errno()          – WSAGetLastError() / errno
+//   close(SOCKET)         – closesocket()
+//   fcntl(SOCKET, int, int) – ioctlsocket(FIONBIO) for O_NONBLOCK only
+//   poll(...)             – WSAPoll()
+//   recvmsg(...)          – WSARecvMsg() (loaded dynamically)
+//   sendmsg(...)          – WSASendMsg() (loaded dynamically)
+//   getsockopt(...)       – casts void* → char* for WinSock2
+//   setsockopt(...)       – casts const void* → const char* for WinSock2
+// ----------------------------------------------------------------------------
 
 #ifdef _MSC_VER
-#    define NOMINMAX
-#    include <WinSock2.h>
-#    include <Windows.h>
-#    include <ws2tcpip.h>
-#else
-#    include <unistd.h>
-#    include <arpa/inet.h>
-#    include <netinet/in.h>
-#    include <poll.h>
-#    include <fcntl.h>
-#    include <sys/types.h>
-#    include <sys/socket.h>
+
+#define NOMINMAX
+#include <WinSock2.h>
+#include <Windows.h>
+#include <ws2tcpip.h>
+#include <mswsock.h>
+#include <cstddef>
+
+// Windows SDK defines `interface` as a macro (expands to `struct`) for COM.
+// This conflicts with any identifier named `interface` in C++ code.
+#ifdef interface
+#undef interface
 #endif
+
+// ---- errno compat ----------------------------------------------------------
+// On Windows, socket errors come from WSAGetLastError(), not errno.
+// sock_errno() abstracts this difference; use it instead of bare errno
+// for all socket-related error checks throughout the library.
+
+inline int sock_errno() noexcept { return ::WSAGetLastError(); }
+
+// Map POSIX errno names to their closest Winsock equivalents so that
+// switch/case error handling in poll_context compiles unchanged.
+#ifndef EWOULDBLOCK
+#define EWOULDBLOCK WSAEWOULDBLOCK
+#endif
+#ifndef EINPROGRESS
+#define EINPROGRESS WSAEINPROGRESS
+#endif
+#ifndef ECONNRESET
+#define ECONNRESET WSAECONNRESET
+#endif
+#ifndef EPIPE
+#define EPIPE WSAECONNRESET // no direct equivalent
+#endif
+#ifndef EINTR
+#define EINTR WSAEINTR
+#endif
+#ifndef EAGAIN
+#define EAGAIN WSAEWOULDBLOCK
+#endif
+#ifndef ECONNREFUSED
+#define ECONNREFUSED WSAECONNREFUSED
+#endif
+
+// ---- iovec -----------------------------------------------------------------
+// Mirrors POSIX struct iovec exactly (iov_base / iov_len field names).
+// Provides an implicit conversion to WSABUF so that WSARecv / WSASend
+// call sites can pass iovec* directly after reinterpret_cast.
+//
+// Note: WSABUF has { ULONG len; CHAR* buf; } – note the reversed order and
+// narrower length type. The conversion handles both differences.
+
+struct iovec {
+    void*         iov_base;
+    ::std::size_t iov_len;
+
+    operator ::WSABUF() const noexcept {
+        return ::WSABUF{static_cast<::ULONG>(iov_len), static_cast<::CHAR*>(iov_base)};
+    }
+};
+
+// ---- msghdr ----------------------------------------------------------------
+// Mirrors POSIX struct msghdr field names so that operations.hpp can assign
+// msg_iov / msg_iovlen / msg_name / msg_namelen without any #ifdef.
+//
+// Provides an implicit conversion to WSAMSG for use with WSARecvMsg /
+// WSASendMsg.  The Control and dwFlags fields default to zero / empty.
+
+struct msghdr {
+    ::SOCKADDR* msg_name    = nullptr;
+    ::INT       msg_namelen = 0;
+    ::iovec*    msg_iov     = nullptr; // our iovec, not WSABUF
+    ::ULONG     msg_iovlen  = 0;
+    ::WSABUF    msg_control = {0, nullptr};
+    ::DWORD     msg_flags   = 0;
+
+    // Build a WSABUF array from our iovec array on the fly.
+    // Called only from recvmsg() / sendmsg() wrappers below.
+    // Intentionally not implicit to avoid accidental temporaries holding
+    // pointers into a stack-allocated WSABUF array.
+    auto to_wsamsg(::WSABUF* bufs, ::ULONG n) noexcept -> ::WSAMSG {
+        for (::ULONG i = 0; i < n; ++i)
+            bufs[i] = static_cast<::WSABUF>(msg_iov[i]);
+        ::WSAMSG w{};
+        w.name          = msg_name;
+        w.namelen       = msg_namelen;
+        w.lpBuffers     = bufs;
+        w.dwBufferCount = n;
+        w.Control       = msg_control;
+        w.dwFlags       = msg_flags;
+        return w;
+    }
+};
+
+// ---- socklen_t -------------------------------------------------------------
+using socklen_t = int;
+
+// ---- pollfd / nfds_t -------------------------------------------------------
+using pollfd = ::WSAPOLLFD;
+using nfds_t = ::ULONG;
+
+inline int poll(::WSAPOLLFD* fds, nfds_t nfds, int timeout) noexcept { return ::WSAPoll(fds, nfds, timeout); }
+
+// ---- close -----------------------------------------------------------------
+inline int close(::SOCKET s) noexcept { return ::closesocket(s); }
+
+// ---- fcntl (O_NONBLOCK only) -----------------------------------------------
+#ifndef F_SETFL
+#define F_SETFL 0
+#endif
+#ifndef O_NONBLOCK
+#define O_NONBLOCK 1
+#endif
+
+inline int fcntl(::SOCKET s, int /*cmd*/, int flags) noexcept {
+    ::u_long mode = (flags & O_NONBLOCK) ? 1u : 0u;
+    return ::ioctlsocket(s, FIONBIO, &mode);
+}
+
+// ---- recvmsg / sendmsg -----------------------------------------------------
+// WSARecvMsg and WSASendMsg are Winsock extension functions that must be
+// loaded at runtime via WSAIoctl.  We load them once (per process) on the
+// first call that provides a valid socket handle.
+
+namespace beman::net::detail::platform {
+inline ::LPFN_WSARECVMSG load_wsarecvmsg(::SOCKET s) noexcept {
+    static ::LPFN_WSARECVMSG pfn = nullptr;
+    if (!pfn) {
+        ::GUID  guid = WSAID_WSARECVMSG;
+        ::DWORD n    = 0;
+        ::WSAIoctl(
+            s, SIO_GET_EXTENSION_FUNCTION_POINTER, &guid, sizeof(guid), &pfn, sizeof(pfn), &n, nullptr, nullptr);
+    }
+    return pfn;
+}
+inline ::LPFN_WSASENDMSG load_wsasendmsg(::SOCKET s) noexcept {
+    static ::LPFN_WSASENDMSG pfn = nullptr;
+    if (!pfn) {
+        ::GUID  guid = WSAID_WSASENDMSG;
+        ::DWORD n    = 0;
+        ::WSAIoctl(
+            s, SIO_GET_EXTENSION_FUNCTION_POINTER, &guid, sizeof(guid), &pfn, sizeof(pfn), &n, nullptr, nullptr);
+    }
+    return pfn;
+}
+} // namespace beman::net::detail::platform
+
+// Maximum scatter-gather segments we support in a single recvmsg/sendmsg call.
+// Allocated on the stack inside the wrappers to avoid heap allocation.
+inline constexpr ::ULONG k_max_iov = 16;
+
+inline int recvmsg(::SOCKET s, msghdr* msg, int /*flags*/) noexcept {
+    auto pfn = ::beman::net::detail::platform::load_wsarecvmsg(s);
+    if (!pfn) {
+        ::WSASetLastError(WSAEOPNOTSUPP);
+        return -1;
+    }
+
+    ::WSABUF bufs[k_max_iov];
+    ::ULONG  n     = (msg->msg_iovlen < k_max_iov) ? msg->msg_iovlen : k_max_iov;
+    ::WSAMSG wm    = msg->to_wsamsg(bufs, n);
+    ::DWORD  bytes = 0;
+    int      rc    = pfn(s, &wm, &bytes, nullptr, nullptr);
+    return rc == 0 ? static_cast<int>(bytes) : -1;
+}
+
+inline int sendmsg(::SOCKET s, msghdr* msg, int /*flags*/) noexcept {
+    auto pfn = ::beman::net::detail::platform::load_wsasendmsg(s);
+    if (!pfn) {
+        ::WSASetLastError(WSAEOPNOTSUPP);
+        return -1;
+    }
+
+    ::WSABUF bufs[k_max_iov];
+    ::ULONG  n     = (msg->msg_iovlen < k_max_iov) ? msg->msg_iovlen : k_max_iov;
+    ::WSAMSG wm    = msg->to_wsamsg(bufs, n);
+    ::DWORD  bytes = 0;
+    int      rc    = pfn(s, &wm, 0, &bytes, nullptr, nullptr);
+    return rc == 0 ? static_cast<int>(bytes) : -1;
+}
+
+// ---- getsockopt / setsockopt -----------------------------------------------
+// WinSock2 requires char* instead of void* for option value pointers.
+// These overloads insert the required cast so call sites compile unchanged.
+
+inline int getsockopt(::SOCKET s, int level, int name, void* val, socklen_t* len) noexcept {
+    return ::getsockopt(s, level, name, static_cast<char*>(val), len);
+}
+inline int setsockopt(::SOCKET s, int level, int name, const void* val, socklen_t len) noexcept {
+    return ::setsockopt(s, level, name, static_cast<const char*>(val), len);
+}
+
+#else // ---- POSIX (Linux / macOS) ------------------------------------------
+
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+
+inline int sock_errno() noexcept { return errno; }
+
+#endif // _MSC_VER
 
 // ----------------------------------------------------------------------------
 

--- a/include/beman/net/detail/platform.hpp
+++ b/include/beman/net/detail/platform.hpp
@@ -14,21 +14,21 @@
 // without any #ifdef outside of this file.
 //
 // Types defined here for Windows:
-//   iovec      – matches POSIX iovec (iov_base / iov_len), converts to WSABUF
-//   msghdr     – matches POSIX msghdr field names, converts to WSAMSG
-//   socklen_t  – int (matches WinSock2 convention)
-//   pollfd     – alias for WSAPOLLFD
-//   nfds_t     – alias for ULONG
+//   iovec      - matches POSIX iovec (iov_base / iov_len), converts to WSABUF
+//   msghdr     - matches POSIX msghdr field names, converts to WSAMSG
+//   socklen_t  - int (matches WinSock2 convention)
+//   pollfd     - alias for WSAPOLLFD
+//   nfds_t     - alias for ULONG
 //
 // Free functions defined here for Windows:
-//   sock_errno()          – WSAGetLastError() / errno
-//   close(SOCKET)         – closesocket()
-//   fcntl(SOCKET, int, int) – ioctlsocket(FIONBIO) for O_NONBLOCK only
-//   poll(...)             – WSAPoll()
-//   recvmsg(...)          – WSARecvMsg() (loaded dynamically)
-//   sendmsg(...)          – WSASendMsg() (loaded dynamically)
-//   getsockopt(...)       – casts void* → char* for WinSock2
-//   setsockopt(...)       – casts const void* → const char* for WinSock2
+//   sock_errno()          - WSAGetLastError() / errno
+//   close(SOCKET)         - closesocket()
+//   fcntl(SOCKET, int, int) - ioctlsocket(FIONBIO) for O_NONBLOCK only
+//   poll(...)             - WSAPoll()
+//   recvmsg(...)          - WSARecvMsg() (loaded dynamically)
+//   sendmsg(...)          - WSASendMsg() (loaded dynamically)
+//   getsockopt(...)       - casts void* -> char* for WinSock2
+//   setsockopt(...)       - casts const void* -> const char* for WinSock2
 // ----------------------------------------------------------------------------
 
 #ifdef _MSC_VER
@@ -82,7 +82,7 @@ inline int sock_errno() noexcept { return ::WSAGetLastError(); }
 // Provides an implicit conversion to WSABUF so that WSARecv / WSASend
 // call sites can pass iovec* directly after reinterpret_cast.
 //
-// Note: WSABUF has { ULONG len; CHAR* buf; } – note the reversed order and
+// Note: WSABUF has { ULONG len; CHAR* buf; } - note the reversed order and
 // narrower length type. The conversion handles both differences.
 
 struct iovec {

--- a/include/beman/net/detail/platform.hpp
+++ b/include/beman/net/detail/platform.hpp
@@ -164,45 +164,45 @@ inline constexpr ::ULONG k_max_iov = 16;
 inline int recvmsg(::SOCKET s, msghdr* msg, int flags) noexcept {
     ::WSABUF bufs[k_max_iov];
     ::ULONG  n = (msg->msg_iovlen < k_max_iov) ? msg->msg_iovlen : k_max_iov;
-    
+
     for (::ULONG i = 0; i < n; ++i) {
         bufs[i] = static_cast<::WSABUF>(msg->msg_iov[i]);
     }
-    
-    ::DWORD bytes = 0;
+
+    ::DWORD bytes   = 0;
     ::DWORD dwFlags = static_cast<::DWORD>(flags);
-    int rc;
-    
+    int     rc;
+
     // 如果有地址，说明是 UDP，用 WSARecvFrom；否则是 TCP，用 WSARecv
     if (msg->msg_name) {
-        ::INT namelen = msg->msg_namelen;
-        rc = ::WSARecvFrom(s, bufs, n, &bytes, &dwFlags, msg->msg_name, &namelen, nullptr, nullptr);
+        ::INT namelen    = msg->msg_namelen;
+        rc               = ::WSARecvFrom(s, bufs, n, &bytes, &dwFlags, msg->msg_name, &namelen, nullptr, nullptr);
         msg->msg_namelen = namelen;
     } else {
         rc = ::WSARecv(s, bufs, n, &bytes, &dwFlags, nullptr, nullptr);
     }
-    
+
     return rc == 0 ? static_cast<int>(bytes) : -1;
 }
 
 inline int sendmsg(::SOCKET s, msghdr* msg, int flags) noexcept {
     ::WSABUF bufs[k_max_iov];
     ::ULONG  n = (msg->msg_iovlen < k_max_iov) ? msg->msg_iovlen : k_max_iov;
-    
+
     for (::ULONG i = 0; i < n; ++i) {
         bufs[i] = static_cast<::WSABUF>(msg->msg_iov[i]);
     }
-    
+
     ::DWORD bytes = 0;
-    int rc;
-    
+    int     rc;
+
     if (msg->msg_name) {
-        rc = ::WSASendTo(s, bufs, n, &bytes, static_cast<::DWORD>(flags), 
-                         msg->msg_name, msg->msg_namelen, nullptr, nullptr);
+        rc = ::WSASendTo(
+            s, bufs, n, &bytes, static_cast<::DWORD>(flags), msg->msg_name, msg->msg_namelen, nullptr, nullptr);
     } else {
         rc = ::WSASend(s, bufs, n, &bytes, static_cast<::DWORD>(flags), nullptr, nullptr);
     }
-    
+
     return rc == 0 ? static_cast<int>(bytes) : -1;
 }
 

--- a/include/beman/net/detail/platform.hpp
+++ b/include/beman/net/detail/platform.hpp
@@ -184,33 +184,48 @@ inline ::LPFN_WSASENDMSG load_wsasendmsg(::SOCKET s) noexcept {
 // Allocated on the stack inside the wrappers to avoid heap allocation.
 inline constexpr ::ULONG k_max_iov = 16;
 
-inline int recvmsg(::SOCKET s, msghdr* msg, int /*flags*/) noexcept {
-    auto pfn = ::beman::net::detail::platform::load_wsarecvmsg(s);
-    if (!pfn) {
-        ::WSASetLastError(WSAEOPNOTSUPP);
-        return -1;
-    }
-
+inline int recvmsg(::SOCKET s, msghdr* msg, int flags) noexcept {
     ::WSABUF bufs[k_max_iov];
-    ::ULONG  n     = (msg->msg_iovlen < k_max_iov) ? msg->msg_iovlen : k_max_iov;
-    ::WSAMSG wm    = msg->to_wsamsg(bufs, n);
-    ::DWORD  bytes = 0;
-    int      rc    = pfn(s, &wm, &bytes, nullptr, nullptr);
+    ::ULONG  n = (msg->msg_iovlen < k_max_iov) ? msg->msg_iovlen : k_max_iov;
+    
+    for (::ULONG i = 0; i < n; ++i) {
+        bufs[i] = static_cast<::WSABUF>(msg->msg_iov[i]);
+    }
+    
+    ::DWORD bytes = 0;
+    ::DWORD dwFlags = static_cast<::DWORD>(flags);
+    int rc;
+    
+    // 如果有地址，说明是 UDP，用 WSARecvFrom；否则是 TCP，用 WSARecv
+    if (msg->msg_name) {
+        ::INT namelen = msg->msg_namelen;
+        rc = ::WSARecvFrom(s, bufs, n, &bytes, &dwFlags, msg->msg_name, &namelen, nullptr, nullptr);
+        msg->msg_namelen = namelen;
+    } else {
+        rc = ::WSARecv(s, bufs, n, &bytes, &dwFlags, nullptr, nullptr);
+    }
+    
     return rc == 0 ? static_cast<int>(bytes) : -1;
 }
 
-inline int sendmsg(::SOCKET s, msghdr* msg, int /*flags*/) noexcept {
-    auto pfn = ::beman::net::detail::platform::load_wsasendmsg(s);
-    if (!pfn) {
-        ::WSASetLastError(WSAEOPNOTSUPP);
-        return -1;
-    }
-
+inline int sendmsg(::SOCKET s, msghdr* msg, int flags) noexcept {
     ::WSABUF bufs[k_max_iov];
-    ::ULONG  n     = (msg->msg_iovlen < k_max_iov) ? msg->msg_iovlen : k_max_iov;
-    ::WSAMSG wm    = msg->to_wsamsg(bufs, n);
-    ::DWORD  bytes = 0;
-    int      rc    = pfn(s, &wm, 0, &bytes, nullptr, nullptr);
+    ::ULONG  n = (msg->msg_iovlen < k_max_iov) ? msg->msg_iovlen : k_max_iov;
+    
+    for (::ULONG i = 0; i < n; ++i) {
+        bufs[i] = static_cast<::WSABUF>(msg->msg_iov[i]);
+    }
+    
+    ::DWORD bytes = 0;
+    int rc;
+    
+    if (msg->msg_name) {
+        rc = ::WSASendTo(s, bufs, n, &bytes, static_cast<::DWORD>(flags), 
+                         msg->msg_name, msg->msg_namelen, nullptr, nullptr);
+    } else {
+        rc = ::WSASend(s, bufs, n, &bytes, static_cast<::DWORD>(flags), nullptr, nullptr);
+    }
+    
     return rc == 0 ? static_cast<int>(bytes) : -1;
 }
 

--- a/include/beman/net/detail/poll_context.hpp
+++ b/include/beman/net/detail/poll_context.hpp
@@ -32,6 +32,22 @@ struct beman::net::detail::poll_record final {
 // ----------------------------------------------------------------------------
 
 struct beman::net::detail::poll_context final : ::beman::net::detail::context_base {
+#ifdef _MSC_VER
+    // On Windows, Winsock must be initialised before any socket call.
+    // This RAII guard calls WSAStartup on construction and WSACleanup on
+    // destruction, tying the Winsock lifetime to the poll_context object.
+    struct wsa_guard {
+        wsa_guard() {
+            ::WSADATA wd{};
+            if (::WSAStartup(MAKEWORD(2, 2), &wd) != 0)
+                throw ::std::system_error(::WSAGetLastError(), ::std::system_category(), "WSAStartup failed");
+        }
+        ~wsa_guard() { ::WSACleanup(); }
+        wsa_guard(const wsa_guard&)            = delete;
+        wsa_guard& operator=(const wsa_guard&) = delete;
+    } d_wsa; // constructed first, destroyed last
+#endif
+
     using time_t       = ::std::chrono::system_clock::time_point;
     using timer_node_t = ::beman::net::detail::context_base::resume_at_operation;
     struct get_time {

--- a/include/beman/net/detail/poll_context.hpp
+++ b/include/beman/net/detail/poll_context.hpp
@@ -177,7 +177,7 @@ struct beman::net::detail::poll_context final : ::beman::net::detail::context_ba
                 }
             } else {
                 for (::std::size_t i(this->d_poll.size()); 0 < i--;) {
-                    if (this->d_poll[i].revents & (this->d_poll[i].events | POLLERR  )) {
+                    if (this->d_poll[i].revents & (this->d_poll[i].events | POLLERR)) {
                         ::beman::net::detail::io_base* completion = this->d_outstanding[i];
                         this->remove_outstanding(i);
                         completion->work(*this, completion);

--- a/include/beman/net/detail/poll_context.hpp
+++ b/include/beman/net/detail/poll_context.hpp
@@ -33,7 +33,7 @@ struct beman::net::detail::poll_record final {
 
 struct beman::net::detail::poll_context final : ::beman::net::detail::context_base {
 #ifdef _MSC_VER
-    // On Windows, Winsock must be initialised before any socket call.
+    // On Windows, Winsock must be initialized before any socket call.
     // This RAII guard calls WSAStartup on construction and WSACleanup on
     // destruction, tying the Winsock lifetime to the poll_context object.
     struct wsa_guard {

--- a/include/beman/net/detail/poll_context.hpp
+++ b/include/beman/net/detail/poll_context.hpp
@@ -46,18 +46,29 @@ struct beman::net::detail::poll_context final : ::beman::net::detail::context_ba
 
     auto make_socket(int fd) -> ::beman::net::detail::socket_id override final { return this->d_sockets.insert(fd); }
     auto make_socket(int d, int t, int p, ::std::error_code& error) -> ::beman::net::detail::socket_id override final {
+        // ::socket() returns SOCKET (ULONG_PTR) on Windows and int on POSIX.
+        // INVALID_SOCKET / -1 are the respective failure sentinels.
+#ifdef _MSC_VER
+        ::SOCKET fd(::socket(d, t, p));
+        if (fd == INVALID_SOCKET) {
+            error = ::std::error_code(sock_errno(), ::std::system_category());
+            return ::beman::net::detail::socket_id::invalid;
+        }
+        return this->make_socket(static_cast<int>(fd)); // narrowing is safe: stored as native_handle_type
+#else
         int fd(::socket(d, t, p));
         if (fd < 0) {
-            error = ::std::error_code(errno, ::std::system_category());
+            error = ::std::error_code(sock_errno(), ::std::system_category());
             return ::beman::net::detail::socket_id::invalid;
         }
         return this->make_socket(fd);
+#endif
     }
     auto release(::beman::net::detail::socket_id id, ::std::error_code& error) -> void override final {
         ::beman::net::detail::native_handle_type handle(this->d_sockets[id].handle);
         this->d_sockets.erase(id);
         if (::close(handle) < 0) {
-            error = ::std::error_code(errno, ::std::system_category());
+            error = ::std::error_code(sock_errno(), ::std::system_category());
         }
     }
     auto native_handle(::beman::net::detail::socket_id id) -> ::beman::net::detail::native_handle_type override final {
@@ -70,19 +81,19 @@ struct beman::net::detail::poll_context final : ::beman::net::detail::context_ba
                     ::socklen_t                     size,
                     ::std::error_code&              error) -> void override final {
         if (::setsockopt(this->native_handle(id), level, name, data, size) < 0) {
-            error = ::std::error_code(errno, ::std::system_category());
+            error = ::std::error_code(sock_errno(), ::std::system_category());
         }
     }
     auto bind(::beman::net::detail::socket_id       id,
               const ::beman::net::detail::endpoint& endpoint,
               ::std::error_code&                    error) -> void override final {
         if (::bind(this->native_handle(id), endpoint.data(), endpoint.size()) < 0) {
-            error = ::std::error_code(errno, ::std::system_category());
+            error = ::std::error_code(sock_errno(), ::std::system_category());
         }
     }
     auto listen(::beman::net::detail::socket_id id, int no, ::std::error_code& error) -> void override final {
         if (::listen(this->native_handle(id), no) < 0) {
-            error = ::std::error_code(errno, ::std::system_category());
+            error = ::std::error_code(sock_errno(), ::std::system_category());
         }
     }
 
@@ -132,7 +143,9 @@ struct beman::net::detail::poll_context final : ::beman::net::detail::context_ba
             }(this->d_poll.size()));
             int    rc(::poll(this->d_poll.data(), sz, timeout));
             if (rc < 0) {
-                switch (errno) {
+                // sock_errno() maps to WSAGetLastError() on Windows, errno on POSIX.
+                // EINTR / EAGAIN macros are mapped to their WSA equivalents in platform.hpp.
+                switch (sock_errno()) {
                 default:
                     return ::std::size_t();
                 case EINTR:
@@ -170,7 +183,12 @@ struct beman::net::detail::poll_context final : ::beman::net::detail::context_ba
             if (bool(completion->event & ::beman::net::event_type::out)) {
                 events |= POLLOUT;
             }
-            this->d_poll.emplace_back(::pollfd{this->native_handle(id), events, short()});
+            // this->d_poll.emplace_back(::pollfd{this->native_handle(id), events, short()});
+            //  pollfd::fd is int on POSIX and SOCKET (ULONG_PTR) on Windows.
+            //  Cast through the actual field type to avoid narrowing warnings on
+            //  both platforms without introducing a #ifdef here.
+            this->d_poll.emplace_back(
+                ::pollfd{static_cast<decltype(::pollfd{}.fd)>(this->native_handle(id)), events, short()});
             this->d_outstanding.emplace_back(completion);
             this->wakeup();
             return ::beman::net::detail::submit_result::submit;
@@ -208,9 +226,9 @@ struct beman::net::detail::poll_context final : ::beman::net::detail::context_ba
                     cmp.complete();
                     return ::beman::net::detail::submit_result::ready;
                 } else {
-                    switch (errno) {
+                    switch (sock_errno()) {
                     default:
-                        cmp.error(::std::error_code(errno, ::std::system_category()));
+                        cmp.error(::std::error_code(sock_errno(), ::std::system_category()));
                         return ::beman::net::detail::submit_result::error;
                     case EINTR:
                         break;
@@ -227,16 +245,16 @@ struct beman::net::detail::poll_context final : ::beman::net::detail::context_ba
         auto        handle{this->native_handle(op->id)};
         const auto& endpoint(::std::get<0>(*op));
         if (-1 == ::fcntl(handle, F_SETFL, O_NONBLOCK)) {
-            op->error(::std::error_code(errno, ::std::system_category()));
+            op->error(::std::error_code(sock_errno(), ::std::system_category()));
             return ::beman::net::detail::submit_result::error;
         }
         if (0 == ::connect(handle, endpoint.data(), endpoint.size())) {
             op->complete();
             return ::beman::net::detail::submit_result::ready;
         }
-        switch (errno) {
+        switch (sock_errno()) {
         default:
-            op->error(::std::error_code(errno, ::std::system_category()));
+            op->error(::std::error_code(sock_errno(), ::std::system_category()));
             return ::beman::net::detail::submit_result::error;
         case EINPROGRESS:
         case EINTR:
@@ -250,7 +268,7 @@ struct beman::net::detail::poll_context final : ::beman::net::detail::context_ba
             int         error{};
             ::socklen_t len{sizeof(error)};
             if (-1 == ::getsockopt(hndl, SOL_SOCKET, SO_ERROR, &error, &len)) {
-                o->error(::std::error_code(errno, ::std::system_category()));
+                o->error(::std::error_code(sock_errno(), ::std::system_category()));
                 return ::beman::net::detail::submit_result::error;
             }
             if (0 == error) {
@@ -276,9 +294,9 @@ struct beman::net::detail::poll_context final : ::beman::net::detail::context_ba
                     completion.complete();
                     return ::beman::net::detail::submit_result::ready;
                 } else
-                    switch (errno) {
+                    switch (sock_errno()) {
                     default:
-                        completion.error(::std::error_code(errno, ::std::system_category()));
+                        completion.error(::std::error_code(sock_errno(), ::std::system_category()));
                         return ::beman::net::detail::submit_result::error;
                     case ECONNRESET:
                     case EPIPE:
@@ -306,9 +324,9 @@ struct beman::net::detail::poll_context final : ::beman::net::detail::context_ba
                     completion.complete();
                     return ::beman::net::detail::submit_result::ready;
                 } else
-                    switch (errno) {
+                    switch (sock_errno()) {
                     default:
-                        completion.error(::std::error_code(errno, ::std::system_category()));
+                        completion.error(::std::error_code(sock_errno(), ::std::system_category()));
                         return ::beman::net::detail::submit_result::error;
                     case ECONNRESET:
                     case EPIPE:

--- a/include/beman/net/detail/poll_context.hpp
+++ b/include/beman/net/detail/poll_context.hpp
@@ -177,7 +177,7 @@ struct beman::net::detail::poll_context final : ::beman::net::detail::context_ba
                 }
             } else {
                 for (::std::size_t i(this->d_poll.size()); 0 < i--;) {
-                    if (this->d_poll[i].revents & (this->d_poll[i].events | POLLERR )) {
+                    if (this->d_poll[i].revents & (this->d_poll[i].events | POLLERR  )) {
                         ::beman::net::detail::io_base* completion = this->d_outstanding[i];
                         this->remove_outstanding(i);
                         completion->work(*this, completion);

--- a/include/beman/net/detail/poll_context.hpp
+++ b/include/beman/net/detail/poll_context.hpp
@@ -80,6 +80,13 @@ struct beman::net::detail::poll_context final : ::beman::net::detail::context_ba
         return this->make_socket(fd);
 #endif
     }
+
+    // Mark a registered socket as non-blocking so that add_outstanding() will
+    // call work() immediately instead of going straight to poll().
+    // Must be called after make_socket() whenever the underlying fd has been
+    // put into non-blocking mode outside of this class (e.g. in accept's work
+    // lambda on Windows where F_GETFL is unavailable).
+    auto set_nonblocking(::beman::net::detail::socket_id id) -> void { this->d_sockets[id].blocking = false; }
     auto release(::beman::net::detail::socket_id id, ::std::error_code& error) -> void override final {
         ::beman::net::detail::native_handle_type handle(this->d_sockets[id].handle);
         this->d_sockets.erase(id);
@@ -170,7 +177,7 @@ struct beman::net::detail::poll_context final : ::beman::net::detail::context_ba
                 }
             } else {
                 for (::std::size_t i(this->d_poll.size()); 0 < i--;) {
-                    if (this->d_poll[i].revents & (this->d_poll[i].events | POLLERR)) {
+                    if (this->d_poll[i].revents & (this->d_poll[i].events | POLLERR )) {
                         ::beman::net::detail::io_base* completion = this->d_outstanding[i];
                         this->remove_outstanding(i);
                         completion->work(*this, completion);
@@ -222,7 +229,24 @@ struct beman::net::detail::poll_context final : ::beman::net::detail::context_ba
             op->cancel();
             cancel_op->cancel();
         } else {
+
+#ifdef _MSC_VER
+            // On Windows, accepted sockets are set non-blocking (blocking=false),
+            // so add_outstanding() calls work() immediately. If work() returns
+            // ready, op->complete() has already been called and op was never
+            // inserted into d_outstanding or d_timeouts.
+            // when_any then tries to cancel the peer op (e.g. the timeout timer)
+            // which arrives here having already fired and been removed from its
+            // queue. This is a normal completion-vs-cancellation race, not an
+            // error. We only need to notify cancel_op so when_any can clean up;
+            // op itself has already completed normally and needs no action.
+            cancel_op->cancel();
+#else
+            // On Linux all accepted sockets remain blocking=true, so work() is
+            // never called immediately and ops are always in a queue when
+            // cancel() is called. Reaching here indicates a real bug.
             std::cerr << "ERROR: poll_context::cancel(): entity not cancelled!\n";
+#endif
         }
     }
     auto schedule(::beman::net::detail::context_base::task* tsk) -> void override {
@@ -236,6 +260,34 @@ struct beman::net::detail::poll_context final : ::beman::net::detail::context_ba
             auto& cmp(*static_cast<accept_operation*>(comp));
 
             while (true) {
+#ifdef _MSC_VER
+                // On Windows, ::accept() returns SOCKET (ULONG_PTR).
+                ::SOCKET rc = ::accept(ctxt.native_handle(id), ::std::get<0>(cmp).data(), &::std::get<1>(cmp));
+                if (rc == INVALID_SOCKET) {
+                    switch (sock_errno()) {
+                    default:
+                        cmp.error(::std::error_code(sock_errno(), ::std::system_category()));
+                        return ::beman::net::detail::submit_result::error;
+                    case WSAEINTR:
+                        break; // retry
+                    case WSAEWOULDBLOCK:
+                        return ::beman::net::detail::submit_result::submit;
+                    }
+                } else {
+                    // Put the new socket into non-blocking mode so that subsequent
+                    // async_receive / async_send calls can attempt work() immediately
+                    // instead of blocking the event loop.
+                    // platform.hpp shims fcntl(F_SETFL, O_NONBLOCK) to ioctlsocket(FIONBIO).
+                    ::fcntl(static_cast<int>(rc), F_SETFL, O_NONBLOCK);
+                    auto new_id = ctxt.make_socket(static_cast<int>(rc));
+                    // make_socket() cannot detect the non-blocking state on Windows
+                    // (no F_GETFL equivalent), so we inform the context explicitly.
+                    static_cast<poll_context&>(ctxt).set_nonblocking(new_id);
+                    ::std::get<2>(cmp) = new_id;
+                    cmp.complete();
+                    return ::beman::net::detail::submit_result::ready;
+                }
+#else
                 int rc = ::accept(ctxt.native_handle(id), ::std::get<0>(cmp).data(), &::std::get<1>(cmp));
                 if (0 <= rc) {
                     ::std::get<2>(cmp) = ctxt.make_socket(rc);
@@ -252,6 +304,7 @@ struct beman::net::detail::poll_context final : ::beman::net::detail::context_ba
                         return ::beman::net::detail::submit_result::submit;
                     }
                 }
+#endif
             }
         };
         return this->add_outstanding(completion);
@@ -268,11 +321,22 @@ struct beman::net::detail::poll_context final : ::beman::net::detail::context_ba
             op->complete();
             return ::beman::net::detail::submit_result::ready;
         }
+#ifdef _MSC_VER
+        // On Windows we must also update the blocking flag in the socket record
+        // because F_GETFL is unavailable and make_socket() defaults to blocking=true.
+        this->set_nonblocking(op->id);
+#endif
         switch (sock_errno()) {
         default:
             op->error(::std::error_code(sock_errno(), ::std::system_category()));
             return ::beman::net::detail::submit_result::error;
         case EINPROGRESS:
+#ifdef _MSC_VER
+        // On Windows a non-blocking connect in progress reports WSAEWOULDBLOCK,
+        // not EINPROGRESS (the two are distinct Winsock error codes even though
+        // platform.hpp maps EINPROGRESS -> WSAEINPROGRESS for other purposes).
+        case WSAEWOULDBLOCK:
+#endif
         case EINTR:
             break;
         }

--- a/include/beman/net/detail/sender.hpp
+++ b/include/beman/net/detail/sender.hpp
@@ -108,9 +108,22 @@ struct beman::net::detail::sender_state : Desc::operation, ::beman::net::detail:
             this->cancel();
             return;
         }
+#ifdef _MSC_VER
+        // On Windows, non-blocking sockets (e.g. accepted sockets marked via
+        // set_nonblocking()) cause add_outstanding() to invoke work() inline.
+        // If work() completes synchronously, it calls complete()/error()/cancel()
+        // internally, which decrements d_outstanding and resumes the coroutine —
+        // potentially destroying `this` before submit() returns.
+        // Calling this->complete() again after that would be a use-after-free.
+        // On Windows we therefore never touch `this` after submit().
+        this->d_data.submit(this);
+#else
+
         if (this->d_data.submit(this) == ::beman::net::detail::submit_result::ready) {
             this->complete();
         }
+
+#endif
     }
     auto complete() -> void override final {
         if (0 == --this->d_outstanding) {

--- a/include/beman/net/detail/sender.hpp
+++ b/include/beman/net/detail/sender.hpp
@@ -112,7 +112,7 @@ struct beman::net::detail::sender_state : Desc::operation, ::beman::net::detail:
         // On Windows, non-blocking sockets (e.g. accepted sockets marked via
         // set_nonblocking()) cause add_outstanding() to invoke work() inline.
         // If work() completes synchronously, it calls complete()/error()/cancel()
-        // internally, which decrements d_outstanding and resumes the coroutine —
+        // internally, which decrements d_outstanding and resumes the coroutine -
         // potentially destroying `this` before submit() returns.
         // Calling this->complete() again after that would be a use-after-free.
         // On Windows we therefore never touch `this` after submit().

--- a/src/beman/net/CMakeLists.txt
+++ b/src/beman/net/CMakeLists.txt
@@ -90,12 +90,7 @@ endif()
 if(WIN32)
     # Always link ws2_32 on Windows: even the poll backend needs WinSock2.
     # mswsock provides AcceptEx, ConnectEx, WSARecvMsg, WSASendMsg.
-    target_link_libraries(
-        ${PROJECT_NAME}_headers
-        INTERFACE
-            ws2_32
-            mswsock
-    )
+    target_link_libraries(${PROJECT_NAME}_headers INTERFACE ws2_32 mswsock)
     if(BEMAN_NET_WITH_IOCP)
         target_compile_definitions(
             ${PROJECT_NAME}_headers

--- a/src/beman/net/CMakeLists.txt
+++ b/src/beman/net/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(
                 ${PROJECT_SOURCE_DIR}/include/beman/net/detail/into_expected.hpp
                 ${PROJECT_SOURCE_DIR}/include/beman/net/detail/netfwd.hpp
                 ${PROJECT_SOURCE_DIR}/include/beman/net/detail/poll_context.hpp
+                ${PROJECT_SOURCE_DIR}/include/beman/net/detail/iocp_context.hpp
                 ${PROJECT_SOURCE_DIR}/include/beman/net/detail/container.hpp
                 ${PROJECT_SOURCE_DIR}/include/beman/net/detail/basic_stream_socket.hpp
                 ${PROJECT_SOURCE_DIR}/include/beman/net/detail/security_props.hpp
@@ -84,4 +85,21 @@ if(LINUX AND BEMAN_NET_WITH_URING)
         ${PROJECT_NAME}_headers
         INTERFACE BEMAN_NET_USE_URING
     )
+endif()
+
+if(WIN32)
+    # Always link ws2_32 on Windows: even the poll backend needs WinSock2.
+    # mswsock provides AcceptEx, ConnectEx, WSARecvMsg, WSASendMsg.
+    target_link_libraries(
+        ${PROJECT_NAME}_headers
+        INTERFACE
+            ws2_32
+            mswsock
+    )
+    if(BEMAN_NET_WITH_IOCP)
+        target_compile_definitions(
+            ${PROJECT_NAME}_headers
+            INTERFACE BEMAN_NET_USE_IOCP
+        )
+    endif()
 endif()


### PR DESCRIPTION
## Description

This PR implements the core network capabilities for Windows platforms, addressing the missing Windows support mentioned in the project's current state. It is intended to be merged into the `windows-support` branch to finalize the cross-platform compatibility.

### Key Implementations:
1. **Default Windows Backend (`WSAPoll`)**: 
   - Provided a functional backend using `WSAPoll`  for basic I/O polling, acting as a counterpart to the POSIX `poll(2)` implementation.
2. **High-Performance Backend (`IOCP`)**: 
   - Added an I/O Completion Ports (IOCP) implementation for high-performance asynchronous networking on Windows.
   - This feature is placed behind a CMake feature flag to keep the default build straightforward. It can be enabled using `-DBEMAN_NET_WITH_IOCP=ON`.

## How to test this locally (Windows):

**Test default WSAPoll:**
```bash
cmake --preset msvc-debug
cmake --build --preset msvc-debug
ctest --preset msvc-debug
```
**Test IOCP backend:**
```bash
cmake --preset msvc-debug  -DBEMAN_NET_WITH_IOCP=ON
cmake --build --preset msvc-debug
ctest --preset msvc-debug
```