### PR TITLE
Update beman-tidy to 0.5.2

### DIFF
--- a/.beman-tidy.yaml
+++ b/.beman-tidy.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This is the config file for beman-tidy, which checks compliance with the Beman Standard (https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md)
+# Check documentation for beman-tidy here:
+# https://github.com/bemanproject/beman-tidy/blob/main/README.md
+
+disabled_rules: []
+
+ignored_paths:
+    - infra/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,14 @@ repos:
         files: ^.*\.(cmake|cpp|cppm|hpp|txt|md|mds|json|js|in|yaml|yml|py|toml)$
         args: ["--write", "--ignore-words", ".codespellignore" ]
 
+
+  # Beman Standard checking via beman-tidy
+  - repo: https://github.com/bemanproject/beman-tidy
+    rev: v0.5.2
+    hooks:
+      - id: beman-tidy
+        args: [".", "--verbose"]
+
   # Clang-format for C++
   # This brings in a portable version of clang-format.
   # See also: https://github.com/ssciwr/clang-format-wheel


### PR DESCRIPTION
## Summary

- Enable `beman-tidy` **0.5.2** in pre-commit
- Add `.beman-tidy.yaml` with `ignored_paths: [infra/]`

## Test plan

- [ ] CI green
- [ ] `pre-commit run beman-tidy --all-files`

Made with [Cursor](https://cursor.com)