### PR TITLE
Align build options and README with Beman Standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ option(
 # [CMAKE.SKIP_EXAMPLES]
 option(
     BEMAN_NET_BUILD_EXAMPLES
-    "Enable building examples. Default: ON. Values: { ON, OFF }."
+    "Enable building examples. Default: ${PROJECT_IS_TOP_LEVEL}. Values: { ON, OFF }."
     ${PROJECT_IS_TOP_LEVEL}
 )
 
@@ -61,7 +61,7 @@ if(BEMAN_NET_BUILD_TESTS)
     add_subdirectory(tests/beman/net)
 endif()
 
-if(${BEMAN_NET_BUILD_EXAMPLES})
+if(BEMAN_NET_BUILD_EXAMPLES)
     message(NOTICE "Building examples")
     add_subdirectory(examples)
 endif()

--- a/README.md
+++ b/README.md
@@ -50,6 +50,22 @@ is using [IETF TAPS](https://datatracker.ietf.org/wg/taps/documents/)
 the implementation will use a lower-level interface which can likely
 use something akin to the current interface.
 
+## Dependencies
+
+### Build Environment
+
+This project requires at least the following to build:
+
+* A C++ compiler that conforms to the C++23 standard or greater
+* CMake 3.30 or later
+* (Test Only) GoogleTest
+
+You can disable building tests by setting CMake option `BEMAN_NET_BUILD_TESTS` to
+`OFF` when configuring the project.
+
+You can disable building examples by setting CMake option `BEMAN_NET_BUILD_EXAMPLES` to
+`OFF` when configuring the project.
+
 ## Building
 
 Currently, the interfaces are entirely implemented in headers, i.e.,


### PR DESCRIPTION
Related to upcoming new beman-tidy features:
- https://github.com/bemanproject/beman-tidy/pull/346 (cmake.skip_tests)
- https://github.com/bemanproject/beman-tidy/pull/358 (cmake.skip_examples)
- https://github.com/bemanproject/beman-tidy/pull/362 (cpp.min_std_version)
- https://github.com/bemanproject/exemplar/pull/417 (Build Environment documentation)

Changes in this library need to be fixed before releasing new beman-tidy including these features.
